### PR TITLE
GUI tweaks related to deep storage

### DIFF
--- a/scripts/GUI/info-gui.lua
+++ b/scripts/GUI/info-gui.lua
@@ -529,6 +529,10 @@ function GUI.updateDeepStorageFrame(player, MF)
 		deepStorageLabel.style.width = 80
 		if deepStorage.inventoryItem ~= nil then
 			Util.itemToLabel(deepStorage.inventoryItem, deepStorage.inventoryCount, deepStorageFlow)
+		else
+			if global.deepStorageTable[k].filter ~= nil and game.item_prototypes[global.deepStorageTable[k].filter] ~= nil then
+				Util.itemToLabel(global.deepStorageTable[k].filter, 0, deepStorageFlow)
+			end
 		end
 		-- Create Deep Storage Filter --
 		local deepStorageFilter = deepStorageFrame.add{type="choose-elem-button", elem_type="item", name="DSRF" .. tostring(k)}

--- a/scripts/objects/matter-printer.lua
+++ b/scripts/objects/matter-printer.lua
@@ -126,11 +126,11 @@ function MP:updateInv()
 	local currentItems = inv.get_contents()[filter.name]
 	
 	-- Calcule the number of Items that must be requested --	
-	returnedItems = math.min(returnedItems, filter.count - (currentItems or 0))
-	
+	returnedItems = math.floor(math.min(returnedItems, filter.count - (currentItems or 0)))
+
 	-- Stop if they are any Item --
 	if returnedItems <= 0 then return end
-	
+
 	-- Insert requested Item inside the local Inventory --
 	local addedItems = inv.insert({name=filter.name, count=returnedItems})
 	
@@ -201,9 +201,11 @@ function MP:getTooltipInfos(GUI)
 			if deepStorage ~= nil and deepStorage.ent ~= nil and Util.canUse(self.player, deepStorage.ent) then
 				i = i + 1
 				local itemText = ""
-				if deepStorage.inventoryItem ~= nil and game.item_prototypes[deepStorage.inventoryItem] ~= nil then
-					itemText = {"", " (", game.item_prototypes[deepStorage.inventoryItem].localised_name, " - ", deepStorage.player, ")"}
-				end
+				if deepStorage.filter ~= nil and game.item_prototypes[deepStorage.filter] ~= nil then
+					itemText = {"", " (", game.item_prototypes[deepStorage.filter].localised_name, " - ", deepStorage.player, ")"}
+				else
+					itemText = {"", " - ",deepStorage.player}
+                end
 				invs[k+1] = {"", {"gui-description.DS"}, " ", tostring(deepStorage.ID), itemText}
 				if self.selectedInv == deepStorage then
 					selectedIndex = i
@@ -212,7 +214,7 @@ function MP:getTooltipInfos(GUI)
 		end
 		if selectedIndex ~= nil and selectedIndex > table_size(invs) then selectedIndex = nil end
 		local invSelection = GUI.add{type="list-box", name="MP" .. self.ent.unit_number, items=invs, selected_index=selectedIndex}
-		invSelection.style.width = 100
+		invSelection.style.width = 140
 	end
 end
 

--- a/scripts/objects/matter-serializer.lua
+++ b/scripts/objects/matter-serializer.lua
@@ -186,8 +186,10 @@ function MS:getTooltipInfos(GUI)
 			if deepStorage ~= nil and deepStorage.ent ~= nil and Util.canUse(self.player, deepStorage.ent) then
 				i = i + 1
 				local itemText = ""
-				if deepStorage.inventoryItem ~= nil and game.item_prototypes[deepStorage.inventoryItem] ~= nil then
-					itemText = {"", " (", game.item_prototypes[deepStorage.inventoryItem].localised_name, " - ", deepStorage.player, ")"}
+				if deepStorage.filter ~= nil and game.item_prototypes[deepStorage.filter] ~= nil then
+					itemText = {"", " (", game.item_prototypes[deepStorage.filter].localised_name, " - ", deepStorage.player, ")"}
+				else
+					itemText = {"", " - ",deepStorage.player}
 				end
 				invs[k+1] = {"", {"gui-description.DS"}, " ", tostring(deepStorage.ID), itemText}
 				if self.selectedInv == deepStorage then
@@ -197,7 +199,7 @@ function MS:getTooltipInfos(GUI)
 		end
 		if selectedIndex ~= nil and selectedIndex > table_size(invs) then selectedIndex = nil end
 		local invSelection = GUI.add{type="list-box", name="MS" .. self.ent.unit_number, items=invs, selected_index=selectedIndex}
-		invSelection.style.width = 100
+		invSelection.style.width = 140
 	end
 end
 

--- a/scripts/objects/ore-cleaner.lua
+++ b/scripts/objects/ore-cleaner.lua
@@ -94,7 +94,10 @@ end
 -- Tooltip Infos --
 function OC:getTooltipInfos(GUI)
 	local ocFrame = GUI.add{type="frame", direction="vertical"}
-	ocFrame.style.width = 150
+	local function inset(element) element.style.width = 140 - 10 end
+	ocFrame.style.width = 140
+	ocFrame.style.left_padding = 0
+	ocFrame.style.right_padding = 0
 
 	-- Create the Belongs to Label --
 	local belongsToL = ocFrame.add{type="label", caption={"", {"gui-description.BelongsTo"}, ": ", self.player}}
@@ -120,12 +123,15 @@ function OC:getTooltipInfos(GUI)
 	ChargeBar.style.color = {176,50,176}
 	PurityLabel.style.font_color = {39,239,0}
 	PurityBar.style.color = {255, 255, 255}
-	
+
+	for _, child in pairs(ocFrame.children) do inset(child) end
+
 	-- Create the Mobile Factory Too Far Label --
 	if self.MFTooFar == true then
 		local mfTooFarL = ocFrame.add{type="label", caption={"", {"gui-description.MFTooFar"}}}
 		mfTooFarL.style.font = "LabelFont"
 		mfTooFarL.style.font_color = _mfRed
+		inset(mfTooFarL)
 	end
 	
 	if canModify(getPlayer(GUI.player_index).name, self.ent) == false then return end
@@ -135,7 +141,7 @@ function OC:getTooltipInfos(GUI)
 	targetLabel.style.top_margin = 7
 	targetLabel.style.font = "LabelFont"
 	targetLabel.style.font_color = {108, 114, 229}
-
+	inset(targetLabel)
 	local invs = {{"gui-description.All"}}
 	local selectedIndex = 1
 	local i = 1
@@ -143,8 +149,10 @@ function OC:getTooltipInfos(GUI)
 		if deepStorage ~= nil and deepStorage.ent ~= nil and Util.canUse(self.player, deepStorage.ent) then
 			i = i + 1
 			local itemText = ""
-			if deepStorage.inventoryItem ~= nil and game.item_prototypes[deepStorage.inventoryItem] ~= nil then
-				itemText = {"", " (", game.item_prototypes[deepStorage.inventoryItem].localised_name, " - ", deepStorage.player, ")"}
+			if deepStorage.filter ~= nil and game.item_prototypes[deepStorage.filter] ~= nil then
+				itemText = {"", " (", game.item_prototypes[deepStorage.filter].localised_name, " - ", deepStorage.player, ")"}
+			else
+				itemText = {"", " - ",deepStorage.player}
 			end
 			invs[k+1] = {"", {"gui-description.DS"}, " ", tostring(deepStorage.ID), itemText}
 			if self.selectedInv == deepStorage then
@@ -154,7 +162,7 @@ function OC:getTooltipInfos(GUI)
 	end
 	if selectedIndex ~= nil and selectedIndex > table_size(invs) then selectedIndex = nil end
 	local invSelection = ocFrame.add{type="list-box", name="OC" .. self.ent.unit_number, items=invs, selected_index=selectedIndex}
-	invSelection.style.width = 100
+	inset(invSelection)
 end
 
 -- Change the Targeted Inventory --


### PR DESCRIPTION
Adds UI for "empty" deep storage cases:
1) shows 0 and filter in main info if no items
2) ore cleaner, matter serializer, and matter printer: deep storage shows owner if no filter
3) filter+player shown if no items but filter present