### PR TITLE
fix drivestat changed bug

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 ---------------------------------------------------------------------------------------------------
 Version: 0.0.121
+Date: 05/04/2020
+  Bugfixes:
+    - player would get teleported back to previous surface if it was from a car-teleport (chronotrain)
+---------------------------------------------------------------------------------------------------
+Version: 0.0.121
 Date: 02/04/2020
   Changes:
     - create flying text if sync area is obstructed

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "Mobile_Factory",
-	"version": "0.0.121",
+	"version": "0.0.122",
 	"title": "Mobile Factory",
 	"author": "Mugiwaxar",
 	"dependencies": ["base >= 0.18", "Mobile_Factory_Graphics >= 0.0.6"],

--- a/scripts/game-update.lua
+++ b/scripts/game-update.lua
@@ -129,7 +129,7 @@ function playerDriveStatChange(event)
 	-- Teleport the player out of reach from Mobile Factoty teleport box --
 	local player = getPlayer(event.player_index)
 	local entity = event.entity
-	if entity == nil or entity.valid == false or player == nil or player.valid == false and string.match(entity.name, "MobileFactory") == false then return end
+	if entity == nil or entity.valid == false or player == nil or player.valid == false or string.find(entity.name, "MobileFactory") == nil then return end
 	if entity.surface.can_place_entity{name="character", position = {entity.position.x + 5, entity.position.y}} then
 		player.teleport({entity.position.x + 5, entity.position.y}, entity.surface)
 	elseif entity.surface.can_place_entity{name="character", position = {entity.position.x -5, entity.position.y}} then


### PR DESCRIPTION
function would always teleport player if it was from a vehicle interaction. string.match returns nil or a string value, never false. Also "and" was being used instead of "or", logic error.