### PR TITLE
temperature and script_raised_revive bugfix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,11 @@
 ---------------------------------------------------------------------------------------------------
-Version: 0.0.121
-Date: 05/04/2020
+Version: 0.0.122
+Date: 10/04/2020
+  Features:
+    - add temperature to Deep Tank interactions (gui addition eventually)
   Bugfixes:
-    - player would get teleported back to previous surface if it was from a car-teleport (chronotrain)
+    - player would get teleported back to previous surface if it was from a vehicle interaction teleport (Chronotrain)
+    - script_raised_revive would break MF recording functions
 ---------------------------------------------------------------------------------------------------
 Version: 0.0.121
 Date: 02/04/2020

--- a/scripts/objects/deep-tank.lua
+++ b/scripts/objects/deep-tank.lua
@@ -9,6 +9,7 @@ DTK = {
 	lastUpdate = 0,
 	inventoryFluid = nil,
 	inventoryCount = 0,
+	inventoryTemperature = 15,
 	ID = 0,
 	filter = nil
 }
@@ -67,12 +68,13 @@ function DTK:update()
 	if self.inventoryFluid ~= nil and game.fluid_prototypes[self.inventoryFluid] == nil then
 		self.inventoryFluid = nil
 		self.inventoryCount = 0
+		self.inventoryTemperature = 0
 		return
 	end
 
 	-- Remove the Fluid Filter if it doesn't exist anymore --
-	if self.filtrer ~= nil and game.fluid_prototypes[self.filtrer] == nil then
-		self.filtrer = nil
+	if self.filter ~= nil and game.fluid_prototypes[self.filter] == nil then
+		self.filter = nil
 		return
 	end
 	
@@ -129,20 +131,22 @@ function DTK:hasFluid(name)
 end
 
 -- Return if the Fluid can be accepted --
-function DTK:canAccept(name)
+function DTK:canAccept(fluid)
 	if self.filter == nil then return false end
-	if self.filter ~= nil and self.filter ~= name then return false end
-    if self.inventoryFluid ~= nil and self.inventoryFluid ~= name then return false end
+	if self.filter ~= nil and self.filter ~= fluid.name then return false end
+    if self.inventoryFluid.name ~= nil and self.inventoryFluid.name ~= fluid.name then return false end
     if self.inventoryCount >= _dtMaxFluid then return false end
 	return true
 end
 
 -- Add Fluid --
-function DTK:addFluid(name, count)
-	if self:canAccept(name) == true then
-        self.inventoryFluid = name
+function DTK:addFluid(fluid)
+	if self:canAccept(fluid.name) == true then
+        self.inventoryFluid = fluid.name
         local maxAdded = _dtMaxFluid - self.inventoryCount
-        local added = math.min(count, maxAdded)
+        local added = math.min(fluid.amount, maxAdded)
+		-- fluid.temperature should always be non-nil, 15 is default temperature
+		local self.inventoryTemperature = (self.inventoryTemperature * self.inventoryCount + added * fluid.temperature) / (self.inventoryCount + added)
 		self.inventoryCount = self.inventoryCount + added
 		return added
 	end
@@ -150,9 +154,9 @@ function DTK:addFluid(name, count)
 end
 
 -- Remove Items --
-function DTK:getFluid(name, count)
-	if self.inventoryFluid ~= nil and self.inventoryFluid == name then
-		local removed = math.min(count, self.inventoryCount)
+function DTK:getFluid(fluid)
+	if self.inventoryFluid ~= nil and self.inventoryFluid == fluid.name then
+		local removed = math.min(fluid.amount, self.inventoryCount)
 		self.inventoryCount = self.inventoryCount - removed
 		if self.inventoryCount == 0 then self.inventoryFluid = nil end
 	end

--- a/scripts/objects/fluid-extractor.lua
+++ b/scripts/objects/fluid-extractor.lua
@@ -188,7 +188,7 @@ function FE:extractFluids(event)
 		inventory = nil
 		for k, dimTank in pairs(global.deepTankTable) do
 			if dimTank ~= nil and dimTank.ent ~= nil and dimTank.ent.valid == true then
-				if dimTank:canAccept(resourceName) then
+				if dimTank:canAccept({name = resourceName}) then
 					inventory = dimTank
 					break
 				end
@@ -200,9 +200,12 @@ function FE:extractFluids(event)
 	-- Calcule the amount that can be extracted --
 	local amount = math.min(self.resource.amount, self:fluidPerExtraction())
 	-- Check if the Distant Tank can accept the fluid --
-	if inventory:canAccept(resourceName, amount) == false then return end
+	if inventory:canAccept({name = resourceName, amount = amount}) == false then return end
 	-- Send the Fluid --
-	local amountAdded = inventory:addFluid(resourceName, amount)
+	--there is no temperature_min, temperature_max for products
+	--will not work for a resource that can provide two fluids (which would require two outputs on pump)
+	local temp = self.resource.prototype.mineable_properties.products[1].temperature or 15
+	local amountAdded = inventory:addFluid({name = resourceName, amount = amount, temperature = temp})
 	-- Test if Fluid was sended --
 	if amountAdded > 0 then
 		self.charge = self.charge - 10

--- a/scripts/objects/fluid-interactor.lua
+++ b/scripts/objects/fluid-interactor.lua
@@ -218,31 +218,32 @@ function FI:updateInventory()
     local localTank = self.ent
     local distantTank = self.selectedInv
     local localFluid = nil
-    local localAmount = nil
 
     -- Get the Fluid inside the local Tank --
-    for k, i in pairs(localTank.get_fluid_contents()) do
-        localFluid = k
-        localAmount = i
+    for i=1,#localTank.fluidbox do
+		if localTank.fluidbox[i] then
+			localFluid = localTank.fluidbox[i]
+			break
+		end
     end
+    if localFluid == nil then return end
 
     -- Input mode --
     if self.selectedMode == "input" then
         -- Check the local and distant Tank --
-        if localFluid == nil or localAmount == nil then return end
         if distantTank:canAccept(localFluid) == false then return end
         -- Send the Fluid --
-        local amountAdded = distantTank:addFluid(localFluid, localAmount)
+        local amountAdded = distantTank:addFluid(localFluid)
         -- Remove the local Fluid --
-		localTank.remove_fluid{name=localFluid, amount=amountAdded}
+		localTank.remove_fluid{name=localFluid.name, amount=amountAdded, minimum_temperature = -200, maximum_temperature = 1000000}
 	-- Output mode --
     elseif self.selectedMode == "output" then
         -- Check the local and distant Tank --
-        if localFluid ~= nil and localFluid ~= distantTank.inventoryFluid then return end
+        if localFluid.name ~= distantTank.inventoryFluid then return end
         if distantTank.inventoryFluid == nil or distantTank.inventoryCount == 0 then return end
         -- Get the Fluid --
-        local amountAdded = localTank.insert_fluid({name=distantTank.inventoryFluid, amount=distantTank.inventoryCount})
+        local amountAdded = localTank.insert_fluid({name=distantTank.inventoryFluid, amount=distantTank.inventoryCount, localFluid.temperature})
         -- Remove the distant Fluid --
-        distantTank:getFluid(distantTank.inventoryFluid, amountAdded)
+        distantTank:getFluid({name = distantTank.inventoryFluid, amount = amountAdded})
     end
 end

--- a/scripts/objects/mobile-factory.lua
+++ b/scripts/objects/mobile-factory.lua
@@ -146,20 +146,20 @@ end
 
 -- Change the Mode --
 function MF:fluidLaserMode(mode)
-    if mode == "left" then
-        self.selectedFluidLaserMode = "input"
-    elseif mode == "right" then
-        self.selectedFluidLaserMode = "output"
-    end
+	if mode == "left" then
+		self.selectedFluidLaserMode = "input"
+	elseif mode == "right" then
+		self.selectedFluidLaserMode = "output"
+	end
 end
 
 -- Change the Fluid Laser Targeted Inventory --
 function MF:fluidLaserTarget(ID)
 	-- Check the ID --
-    if ID == nil then
-        self.selectedInv = nil
-        return
-    end
+	if ID == nil then
+		self.selectedInv = nil
+		return
+	end
 	-- Select the Inventory --
 	self.selectedInv = nil
 	for k, deepTank in pairs(global.deepTankTable) do
@@ -253,10 +253,10 @@ end
 -- Change the Power Laser to Drain or Send mode --
 function MF:changePowerLaserMode(mode)
 	if mode == "left" then
-        self.selectedPowerLaserMode = "input"
-    elseif mode == "right" then
-        self.selectedPowerLaserMode = "output"
-    end
+		self.selectedPowerLaserMode = "input"
+	elseif mode == "right" then
+		self.selectedPowerLaserMode = "output"
+	end
 end
 
 -- Scan all Entities around the Mobile Factory --
@@ -358,26 +358,26 @@ function MF:updateFluidLaser(entity)
 	if entity.type ~= "storage-tank" or self.selectedInv == nil then return false end
 
 	-- Get both Tanks and their characteristics --
-    local localTank = entity
-    local distantTank = self.selectedInv
-    local localFluid = nil
-	local localAmount = nil
+	local localTank = entity
+	local distantTank = self.selectedInv
+	local localFluid = nil
 	
 	-- Get the Fluid inside the local Tank --
-    for k, i in pairs(localTank.get_fluid_contents()) do
-        localFluid = k
-        localAmount = i
+	for i=1,#localTank.fluidbox do
+		if localTank.fluidbox[i] then
+			localFluid = localTank.fluidbox[i]
+		end
 	end
+	if localFluid == nil then return end
 	
 	-- Input mode --
-    if self.selectedFluidLaserMode == "input" then
-        -- Check the local and distant Tank --
-        if localFluid == nil or localAmount == nil then return end
-        if distantTank:canAccept(localFluid) == false then return end
-        -- Send the Fluid --
-        local amountAdded = distantTank:addFluid(localFluid, localAmount)
-        -- Remove the local Fluid --
-		localTank.remove_fluid{name=localFluid, amount=amountAdded}
+	if self.selectedFluidLaserMode == "input" then
+		-- Check the local and distant Tank --
+		if distantTank:canAccept(localFluid) == false then return end
+		-- Send the Fluid --
+		local amountAdded = distantTank:addFluid(localFluid)
+		-- Remove the local Fluid --
+		localTank.remove_fluid({name=localFluid, amount=amountAdded})
 		if amountAdded > 0 then
 			-- Create the Laser --
 			self.ent.surface.create_entity{name="PurpleBeam", duration=60, position=self.ent.position, target=localTank.position, source=self.ent.position}
@@ -386,14 +386,14 @@ function MF:updateFluidLaser(entity)
 			-- One less Beam to the Beam capacity --
 			return true
 		end
-    elseif self.selectedFluidLaserMode == "output" then
-        -- Check the local and distant Tank --
-        if localFluid ~= nil and localFluid ~= distantTank.inventoryFluid then return end
-        if distantTank.inventoryFluid == nil or distantTank.inventoryCount == 0 then return end
-        -- Get the Fluid --
-        local amountAdded = localTank.insert_fluid({name=distantTank.inventoryFluid, amount=distantTank.inventoryCount})
-        -- Remove the distant Fluid --
-		distantTank:getFluid(distantTank.inventoryFluid, amountAdded)
+	elseif self.selectedFluidLaserMode == "output" then
+		-- Check the local and distant Tank --
+		if localFluid.name ~= distantTank.inventoryFluid then return end
+		if distantTank.inventoryFluid == nil or distantTank.inventoryCount == 0 then return end
+		-- Get the Fluid --
+		local amountAdded = localTank.insert_fluid({name=distantTank.inventoryFluid, amount=distantTank.inventoryCount})
+		-- Remove the distant Fluid --
+		distantTank:getFluid({name = distantTank.inventoryFluid, amount = amountAdded})
 		if amountAdded > 0 then
 			-- Create the Laser --
 			self.ent.surface.create_entity{name="PurpleBeam", duration=60, position=self.ent.position, target=localTank.position, source=self.ent.position}
@@ -402,7 +402,7 @@ function MF:updateFluidLaser(entity)
 			-- One less Beam to the Beam capacity --
 			return true
 		end
-    end
+	end
 end
 
 -------------------------------------------- Logistic Laser --------------------------------------------

--- a/utils/place-and-remove.lua
+++ b/utils/place-and-remove.lua
@@ -1,10 +1,18 @@
 -- Called when something is placed --
 function somethingWasPlaced(event, isRobot)
-	local cent = event.created_entity
-	-- Get the Entity if needed
-	if cent == nil and event.entity ~= nil then
-		cent = event.entity
+	--script_raised_revive uses entity, and breaks every single save<Entity> function
+	local fake_event = {}
+	for k, v in pairs(event) do
+		fake_event[k] = v
 	end
+	if fake_event.entity and fake_event.created_entity == nil then
+		fake_event.created_entity = fake_event.entity
+	end
+	event = fake_event
+
+	-- Get the Entity
+	local cent = event.created_entity
+
 	-- This is a Player or not --
 	local isPlayer = false
 	-- Creator variable --
@@ -16,7 +24,6 @@ function somethingWasPlaced(event, isRobot)
 		isPlayer = true
 		creator = getPlayer(event.player_index)
 	end
-
 
 	-- Get the Player Mobile Factory --
 	local MF = nil


### PR DESCRIPTION
First pass at adding temperature support to Deep Tanks (not shown in gui, yet)

The event script_raised_revive uses entity, not created_entity, and breaks every save<Entity> function in somethingwasPlaced()