### PR TITLE
bugfix new global.syncTile and somethingWasPlaced

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.0.131
+Date: 24/04/2020
+  Changes:
+    - Dimensional Tile can't be placed onto void
+  Bugfixes:
+    - valid_for_read checks on item stack while placing some MF entities (mod compatibility?)
+    - variable could go un-inited and error when establishing Sync Area
+---------------------------------------------------------------------------------------------------
 Version: 0.0.130
 Date: 24/04/2020
   Changes:

--- a/control.lua
+++ b/control.lua
@@ -91,6 +91,8 @@ function onInit()
 	global.eryaTable = {}
 	global.eryaIndexedTable = {}
     global.syncTile = "dirt-7"
+	-- Validate the Tile Used for the Sync Area --
+	validateSyncAreaTile()
 end
 
 -- When a save is loaded --
@@ -195,6 +197,9 @@ function onConfigurationChanged()
 	for k, player in pairs(game.players) do
 		GUI.createMFMainGUI(player)
 	end
+
+	-- Validate the Tile Used for the Sync Area --
+	validateSyncAreaTile()
 end
 
 -- Filters --

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "Mobile_Factory",
-	"version": "0.0.130",
+	"version": "0.0.131",
 	"title": "Mobile Factory",
 	"author": "Mugiwaxar",
 	"dependencies": ["base >= 0.18", "Mobile_Factory_Graphics >= 0.0.6"],

--- a/prototypes/tile/dimensional-tile.lua
+++ b/prototypes/tile/dimensional-tile.lua
@@ -3,7 +3,10 @@
 -- Entity --
 local dtE = table.deepcopy(data.raw.tile["refined-concrete"])
 dtE.name = "DimensionalTile"
-dtE.minable = {mining_time = 0.1, result = "DimensionalTile"}
+dtE.minable = {
+	mining_time = .1,
+    result = "DimensionalTile"
+}
 dtE.variants.material_background =
 {
     picture = "__Mobile_Factory_Graphics__/graphics/entity/DimensionalTileE.png",
@@ -25,7 +28,7 @@ dtI.place_as_tile =
     {
       result = "DimensionalTile",
       condition_size = 1,
-      condition = {}
+      condition = { "water-tile" }
     }
 data:extend{dtI}
 

--- a/utils/place-and-remove.lua
+++ b/utils/place-and-remove.lua
@@ -73,7 +73,7 @@ function somethingWasPlaced(event, isRobot)
 			newMobileFactory(cent)
 		end
 	end
-	
+
 	-- Prevent to place listed entities outside the Mobile Factory --
 	if string.match(cent.surface.name, _mfSurfaceName) == nil then
 		if canBePlacedOutside(cent.name) == false then
@@ -128,7 +128,7 @@ function somethingWasPlaced(event, isRobot)
 		local tile = cent.surface.find_tiles_filtered{position=cent.position, radius=1, limit=1}
 		if tile[1] ~= nil and tile[1].valid == true and tile[1].name == "BuildTile" then
 			placedDeepStorage(event)
-			if event.stack ~= nil then
+			if event.stack ~= nil and event.stack.valid_for_read == true then
 				local tags = event.stack.get_tag("Infos")
 				if tags ~= nil then
 					global.deepStorageTable[cent.unit_number].inventoryItem = tags.inventoryItem
@@ -144,7 +144,7 @@ function somethingWasPlaced(event, isRobot)
 		local tile = cent.surface.find_tiles_filtered{position=cent.position, radius=1, limit=1}
 		if tile[1] ~= nil and tile[1].valid == true and tile[1].name == "BuildTile" then
 			placedDeepTank(event)
-			if event.stack ~= nil then
+			if event.stack ~= nil and event.stack.valid_for_read == true then
 				local tags = event.stack.get_tag("Infos")
 				if tags ~= nil then
 					global.deepTankTable[cent.unit_number].inventoryFluid = tags.inventoryFluid
@@ -157,9 +157,9 @@ function somethingWasPlaced(event, isRobot)
 	
 	-- Prevent to place things inside the Control Center --
 	if string.match(cent.surface.name, _mfControlSurfaceName) then
-		if isPlayer == true and event.stack ~= nil and event.stack.valid_for_read == true then creator.print({"", {"item-name." .. event.stack.name }, " ", {"gui-description.CCNotPlaceable"}}) end
 		cent.destroy()
 		if isPlayer == true and event.stack ~= nil and event.stack.valid_for_read == true then
+			creator.print({"", {"item-name." .. event.stack.name }, " ", {"gui-description.CCNotPlaceable"}})
 			creator.get_main_inventory().insert(event.stack)
 		end
 		return
@@ -167,9 +167,9 @@ function somethingWasPlaced(event, isRobot)
 	
 	-- Prevent to place things out of the Control Center --
 	if cent.name == "DeepStorage" or cent.name == "DeepTank" then
-		if isPlayer == true and event.stack ~= nil and event.stack.valid_for_read == true then creator.print({"", {"item-name." .. event.stack.name }, " ", {"gui-description.PlaceableInsideTheCCCArea"}}) end
 		cent.destroy()
 		if isPlayer == true and event.stack ~= nil and event.stack.valid_for_read == true then
+			creator.print({"", {"item-name." .. event.stack.name }, " ", {"gui-description.PlaceableInsideTheCCCArea"}})
 			creator.get_main_inventory().insert(event.stack)
 		end
 		return
@@ -228,7 +228,7 @@ function somethingWasPlaced(event, isRobot)
 	-- Save the Data Center --
 	if cent.name == "DataCenter" then
 		placedDataCenter(event)
-		if event.stack ~= nil then
+		if event.stack ~= nil and event.stack.valid_for_read == true then
 			local tags = event.stack.get_tag("Infos")
 			if tags ~= nil then
 				global.dataCenterTable[cent.unit_number].invObj.inventory = tags.inventory
@@ -252,7 +252,7 @@ function somethingWasPlaced(event, isRobot)
 	-- Save the Energy Cube --
 	if string.match(cent.name, "EnergyCube") then
 		placedEnergyCube(event)
-		if event.stack ~= nil then
+		if event.stack ~= nil and event.stack.valid_for_read == true then
 			local tags = event.stack.get_tag("Infos")
 			if tags ~= nil then
 				global.energyCubesTable[cent.unit_number].ent.energy = tags.energy
@@ -264,9 +264,9 @@ function somethingWasPlaced(event, isRobot)
 	-- Save the Data Center MF --
 	if cent.name == "DataCenterMF" then
 		if MF ~= nil and valid(MF.dataCenter) == true then
-			if isPlayer == true then creator.print({"", {"gui-description.MaxPlaced"}, " ", {"item-name." .. event.stack.name }}) end
 			cent.destroy()
 			if isPlayer == true and event.stack ~= nil and event.stack.valid_for_read == true then
+				creator.print({"", {"gui-description.MaxPlaced"}, " ", {"item-name." .. event.stack.name }})
 				creator.get_main_inventory().insert(event.stack)
 			end
 			return
@@ -285,7 +285,7 @@ function somethingWasPlaced(event, isRobot)
 	-- Save the Ore Cleaner --
 	if cent.name == "OreCleaner" then
 		placedOreCleaner(event)
-		if event.stack ~= nil then
+		if event.stack ~= nil and event.stack.valid_for_read == true then
 			local tags = event.stack.get_tag("Infos")
 			if tags ~= nil then
 				global.oreCleanerTable[cent.unit_number].purity = tags.purity
@@ -299,7 +299,7 @@ function somethingWasPlaced(event, isRobot)
 	-- Save the Fluid Extractor --
 	if cent.name == "FluidExtractor" then
 		placedFluidExtractor(event)
-		if event.stack ~= nil then
+		if event.stack ~= nil and event.stack.valid_for_read == true then
 			local tags = event.stack.get_tag("Infos")
 			if tags ~= nil then
 				global.fluidExtractorTable[cent.unit_number].purity = tags.purity
@@ -313,7 +313,7 @@ function somethingWasPlaced(event, isRobot)
 	-- Save the Jet Flag --
 	if string.match(cent.name, "Flag") then
 		placedJetFlag(event)
-		if event.stack ~= nil then
+		if event.stack ~= nil and event.stack.valid_for_read == true then
 			local tags = event.stack.get_tag("Infos")
 			if tags ~= nil then
 				global.jetFlagTable[cent.unit_number].inventory = tags.inventory

--- a/utils/surface.lua
+++ b/utils/surface.lua
@@ -23,32 +23,6 @@ function createMFSurface(MF)
 	newSurface.force_generate_chunk_requests()
 	-- Set tiles --
 	createTilesSurface(newSurface, -50, -50, 50, 50, "tutorial-grid")
-    -- Workaround if Default Sync dirt-7 Tile Is Missing -- 
-    local tileName
-    if game.tile_prototypes[global.syncTile] == nil then
-      global.syncTile = nil
-      for tileName in pairs(game.tile_prototypes) do
-        if string.find(tileName, "grass") then
-          global.syncTile = tileName
-          break
-        end
-      end
-
-      -- Alien Biomes or another mod leaves grass-1 alone but makes all the dirt colorful
-      if global.syncTile == nil then
-        for tileName in pairs(game.tile_prototypes) do
-          if string.find(tileName, "dirt") then
-            global.syncTile = tileName
-            break
-          end
-        end      
-      end
-      if global.syncTile == nil then
-        error("Unable to find suitable tile for Sync Area.")
-      end
-    end
-
-
 	createTilesSurface(newSurface, _mfSyncAreaPosition.x - _mfSyncAreaRadius, _mfSyncAreaPosition.y - _mfSyncAreaRadius, _mfSyncAreaPosition.x + _mfSyncAreaRadius, _mfSyncAreaPosition.y + _mfSyncAreaRadius, global.syncTile)
 	createTilesSurface(newSurface, _mfSyncAreaPosition.x - 2, _mfSyncAreaPosition.y - 4, _mfSyncAreaPosition.x + 2, _mfSyncAreaPosition.y + 4, "DimensionalTile")
 	createTilesSurface(newSurface, _mfSyncAreaPosition.x - 4, _mfSyncAreaPosition.y - 2, _mfSyncAreaPosition.x + 4, _mfSyncAreaPosition.y + 2, "DimensionalTile")
@@ -115,4 +89,36 @@ function createSyncAreaMFSurface(surface, dirt)
 	createTilesSurface(surface, _mfSyncAreaPosition.x - 4, _mfSyncAreaPosition.y - 2, _mfSyncAreaPosition.x + 4, _mfSyncAreaPosition.y + 2, "DimensionalTile")
 	createTilesSurface(surface, _mfSyncAreaPosition.x - 3, _mfSyncAreaPosition.y - 3, _mfSyncAreaPosition.x + 3, _mfSyncAreaPosition.y + 3, "DimensionalTile")
 	createTilesSurface(surface, -1, -1, 1, 1, "refined-hazard-concrete-right")
+end
+
+function validateSyncAreaTile()
+	-- Workaround if Un-Inited, Simpler Than Migration --
+	if global.syncTile == nil then
+		global.syncTile = "dirt-7"
+	end
+	-- Workaround if Default Sync Tile dirt-7 Is Missing --
+	if game.tile_prototypes[global.syncTile] == nil then
+		global.syncTile = nil
+
+		-- Check for grass-1 First --
+		for tileName in pairs(game.tile_prototypes) do
+			-- Alien Biomes (or other mod) leaves grass-1 alone, but makes all dirt colorful
+			if string.find(tileName, "grass") then
+				global.syncTile = tileName
+				break
+			end
+		end
+
+		if global.syncTile == nil then
+			for tileName in pairs(game.tile_prototypes) do
+				if string.find(tileName, "dirt") then
+					global.syncTile = tileName
+					break
+				end
+			end			
+		end
+		if global.syncTile == nil then
+			error("Unable to find suitable tile for Sync Area.")
+		end
+	end
 end


### PR DESCRIPTION
global.Synctile could go un-inited, leaving it nil when syncing

somethingWasPlaced didn't check if a LuaItemStack was valid_for_read'ing. Caused a mod conflict for unknown reasons. May have to further bugfix