### PR TITLE
initial blueprint support, copy-paste fix, cj ghost patches, error ch…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,27 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.0.135
+Date: 28/04/2020
+  Features:
+    - blueprinting will transfer some settings (experimental):
+        ***only can copy settings if the player blueprinting matches the set Deep Storages and Deep Tanks***
+        ***however, if player has Storages/Tanks matching the copied filter, it will try to use them***
+        ***attempted to make usable across saves (makes a guess if the exact Storage/Tank is not found)***
+        Matter Interactor: (if matching) Deep Storage, (else) Deep Storage filter, self-filter (always set), Mode
+        Fluid Interactor: (if matching) Deep Tank, (else) Deep Tank Filter, Mode. No temperature support at the moment.
+  Changes:
+    - check for necessary tiles, and error with specific message if we're missing any
+    - Construction Jets can place Tiles
+    - Construction Jets can queue 1000 ghost, but a "Jets" option permits <= 25,000 for mass tile placement
+         (performance concern - I can increase max if it's not that bad)
+	- "too many" ghosts keeps existing construction table, and ignores new ghosts (previously emptied the table)
+	- "too many ghosts" is a localized string that prints only to MF owner that places ghosts
+  Scripting:
+    - use ghost.revive() instead of destroying and creating a thing for construction jets
+    - the construction ghost table is global at present (but size option is not).
+                  This is bad. Will try to get to it by next version. (ghosts should be stored per-player / MF)
+  BugFixes:
+    - input/output would not be set on copy/pasting with Matter Interactor and Fluid Interactor
+---------------------------------------------------------------------------------------------------
 Version: 0.0.134
 Date: 27/04/2020
   Changes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "Mobile_Factory",
-	"version": "0.0.134",
+	"version": "0.0.135",
 	"title": "Mobile Factory",
 	"author": "Mugiwaxar",
 	"dependencies": ["base >= 0.18", "Mobile_Factory_Graphics >= 0.0.6"],

--- a/locale/en/config.cfg
+++ b/locale/en/config.cfg
@@ -708,6 +708,8 @@ RepairJetDistanceOpt=Repair Jet
 RepairJetDistanceOptTT=The Maximum Distance between the Repair Jet and the Mobile Factory (Default: 130, will be reset if <10 or >1000)
 CombatJetDistanceOpt=Combat Jet
 CombatJetDistanceOptTT=The Launch Distance between the Combat Jet and a threat near the Mobile Factory (Default: 50, will be reset if <10 or >1000)
+ConstructionJetTableSizeOpt=Construction Jet Ghosts
+ConstructionJetTableSizeOptTT=The count of ghosts the Construction Jets can plan to build. (Default: 1000, will be reset if <1000 or >25000)
 FloorIsLavaTitle=Floor Is Lava
 FloorIsLavaOpt=Active Floor Is Lava
 FloorIsLavaOptTT=The radioactivity is very strong, and the floor will damage you. Only the Dimensional Tile can save you from imminent death. (Admin only)
@@ -808,3 +810,4 @@ JetHealth=Health
 [info]
 MF-sync-collision=Obstruction Detected, No Sync
 MF-sync-too-close=Mobile Factorys Too Close, No Sync
+cjTooManyGhosts=Mobile Factory: Construction Table is at the limit of __1__

--- a/migrations/0.0.a134to0.0.135.lua
+++ b/migrations/0.0.a134to0.0.135.lua
@@ -1,0 +1,6 @@
+
+for _, MF in pairs(global.MFTable) do
+	if MF.varTable and MF.varTable.jets then
+		MF.varTable.jets.cjTableSize = 1000
+	end
+end

--- a/scripts/GUI/option-gui.lua
+++ b/scripts/GUI/option-gui.lua
@@ -143,6 +143,8 @@ function GUI.updateOptionGUIGameTab(GUIObj)
 	GUI.addOption("RepairJetDistanceOpt", scrollPane, "numberfield", false, {text=jets.rjMaxDistance or _MFRepairJetDefaultMaxDistance, text2={"gui-description.RepairJetDistanceOpt"}, tooltip={"gui-description.RepairJetDistanceOptTT"}}, playerIndex)
 	GUI.addOption("CombatJetDistanceOpt", scrollPane, "numberfield", false, {text=jets.cbjMaxDistance or _MFCombatJetDefaultMaxDistance, text2={"gui-description.CombatJetDistanceOpt"}, tooltip={"gui-description.CombatJetDistanceOptTT"}}, playerIndex)
 
+	GUI.addOption("ConstructionJetTableSizeOpt", scrollPane, "numberfield", false, {text=jets.cjTableSize or _MFConstructionJetDefaultTableSize, text2={"gui-description.ConstructionJetTableSizeOpt"}, tooltip={"gui-description.ConstructionJetTableSizeOptTT"}}, playerIndex)
+
 	-- Add Floor Is Lava Option --
 	GUI.addOption("", scrollPane, "title", false, {text={"gui-description.FloorIsLavaTitle"}}, playerIndex)
 	local FILOption = GUI.addOption("FloorIsLavaOpt", scrollPane, "checkbox", false, {text={"gui-description.FloorIsLavaOpt"}, tooltip={"gui-description.FloorIsLavaOptTT"}, state=global.floorIsLavaActivated or false}, playerIndex)

--- a/scripts/GUI/options.lua
+++ b/scripts/GUI/options.lua
@@ -60,6 +60,12 @@ function GUI.readOptions(option, player)
 			MF.varTable.jets.cbjMaxDistance = _MFCombatJetDefaultMaxDistance
 		end
 	end
+	if name == "ConstructionJetTableSizeOpt" then
+		MF.varTable.jets.cjTableSize = tonumber(option.text)
+		if MF.varTable.jets.cjTableSize == nil or MF.varTable.jets.cjTableSize < 1000 or MF.varTable.jets.cjTableSize > 25000 then
+			MF.varTable.jets.cjTableSize = _MFConstructionJetDefaultTableSize
+		end
+	end
 	if name == "FloorIsLavaOpt" then
 		global.floorIsLavaActivated = option.state
 		if global.floorIsLavaActivated == true then

--- a/scripts/objects/construction-jet.lua
+++ b/scripts/objects/construction-jet.lua
@@ -181,14 +181,18 @@ function CJ:build()
 	end
 	self.currentOrder = "Build"
 	self.ent.set_command({type=defines.command.stop})
+--[[
 	-- Destroy the Gost --
 	self.target.ent.destroy()
-	-- Create the Entity --
-	local ent = self.ent.surface.create_entity{name=self.target.name, position=self.target.position, direction=self.target.direction, force=self.ent.force, player=self.player, raise_built=true}
+--]]
+	-- Revive the Ghost (Preserves recipes, modules, etc) --
+	local _, ent = self.target.ent.revive({raise_revive = true})
 	-- Empty the Inventory --
 	self.inventoryItem = nil
 	-- Make the Beam --
-	self.ent.surface.create_entity{name="GreenBeam", duration=15, position=self.ent.position, target=ent.position, source=self.ent.position}
+	if ent then -- a ghost can be placed underneath a cliff... one exception where the ghost won't be revived correctly
+		self.ent.surface.create_entity{name="GreenBeam", duration=15, position=self.ent.position, target=ent.position, source=self.ent.position}
+	end
 	-- Return to the Mobile Factory --
 	self:goMF()
 end

--- a/scripts/objects/fluid-interactor.lua
+++ b/scripts/objects/fluid-interactor.lua
@@ -68,7 +68,7 @@ function FI:copySettings(obj)
 		self.selectedInv = obj.selectedInv
     end
     if obj.selectedMode ~= nil then
-		self.mode = obj.mode
+		self.selectedMode = obj.selectedMode
 	end
 end
 
@@ -247,4 +247,40 @@ function FI:updateInventory()
         -- Remove the distant Fluid --
         distantTank:getFluid({name = distantTank.inventoryFluid, amount = amountAdded})
     end
+end
+
+function FI:settingsToTags()
+    local tags = {}
+    local filter = nil
+	local ID = nil
+
+	-- Get Deep Tank and Filter --
+	if self.selectedInv and valid(self.selectedInv) then
+		ID = self.selectedInv.ID
+		filter = self.selectedInv.filter
+	end
+
+	tags["deepTankID"] = ID
+	tags["deepTankFilter"] = filter
+    tags["selectedMode"] = self.selectedMode
+	return tags
+end
+
+function FI:tagsToSettings(tags)
+	local ID = tags["deepTankID"]
+	local filter = tags["deepTankFilter"]
+	--self.selectedInv = tags["selectedInv"]
+	for k, deepTank in pairs(global.deepTankTable) do
+		if valid(deepTank) and deepTank.player == self.player then
+			if deepTank.ID == ID and filter == deepTank.filter then
+				self.selectedInv = deepTank
+				break
+			elseif filter == deepTank.filter then
+				self.selectedInv = deepTank
+			end
+		end
+	end
+
+	-- be careful of a nil selectedMode
+    if tags["selectedMode"] then self.selectedMode = tags["selectedMode"] end
 end

--- a/scripts/objects/matter-interactor.lua
+++ b/scripts/objects/matter-interactor.lua
@@ -70,7 +70,7 @@ function MI:copySettings(obj)
 		self.selectedInv = obj.selectedInv
     end
     if obj.selectedMode ~= nil then
-		self.mode = obj.mode
+		self.selectedMode = obj.selectedMode
     end
 end
 
@@ -255,4 +255,39 @@ function MI:updateInventory()
     end
 
 
+end
+
+function MI:settingsToTags()
+    local tags = {}
+	tags["selfFilter"] = self.selectedFilter
+	if self.selectedInv and valid(self.selectedInv) then
+		tags["deepStorageID"] = self.selectedInv.ID
+		tags["deepStorageFilter"] = self.selectedInv.filter
+	end
+    tags["selectedMode"] = self.selectedMode
+	return tags
+end
+
+function MI:tagsToSettings(tags)
+	self.selectedFilter = tags["selfFilter"]
+	local ID = tags["deepStorageID"]
+	local deepStorageFilter = tags["deepStorageFilter"]
+	if ID then
+		for _, deepStorage in pairs(global.deepStorageTable) do
+			if valid(deepStorage) then
+				if self.player == deepStorage.player then
+					if ID == deepStorage.ID and deepStorageFilter == deepStorage.filter then
+						-- We Should Have the Exact Inventory --
+						self.selectedInv = deepStorage
+						break
+					elseif deepStorageFilter ~= nil and deepStorageFilter == deepStorage.filter then
+						-- We Have A Similar Inventory And Will Keep Checking --
+						self.selectedInv = deepStorage
+					end
+				end
+			end
+		end
+	end
+
+    if tags["selectedMode"] then self.selectedMode = tags["selectedMode"] end
 end

--- a/utils/functions.lua
+++ b/utils/functions.lua
@@ -584,3 +584,30 @@ function canModify(playerName, structure)
 	end
 	return false
 end
+
+-- Check if We Have Necessary Tiles --
+function checkNeededTiles()
+	local tilesToCheck = {
+		"BuildTile",
+		"tutorial-grid",
+		"VoidTile",
+		"DimensionalTile",
+	}
+
+	for _, tile in pairs(tilesToCheck) do
+		if game.tile_prototypes[tile] == nil then
+			error("Missing "..tile..". This is likely because you have more than 255 tiles.")
+		end
+	end
+end
+
+function entityToBluePrintTags(entity, fromTable)
+	local tags = nil
+	local obj = fromTable[entity.unit_number]
+
+	if obj and obj.settingsToTags then
+		tags = obj:settingsToTags()
+	end
+
+	return tags
+end

--- a/utils/place-and-remove.lua
+++ b/utils/place-and-remove.lua
@@ -176,13 +176,17 @@ function somethingWasPlaced(event, isRobot)
 	end
 
 	-- Save the Ghost inside the Construction Table --
-	if cent ~= nil and cent.valid == true and cent.name == "entity-ghost" and
+	if cent ~= nil and cent.valid == true and (cent.name == "entity-ghost" or cent.name == "tile-ghost") and
 	MF ~= nil and MF.ent ~= nil and MF.ent.valid == true and cent.surface.name == MF.ent.surface.name then
-		if table_size(global.constructionTable) > 1000 then
-			game.print("Mobile Factory: To many Blueprint inside the Construction Table")
-			global.constructionTable = {}
+		if table_size(global.constructionTable) >= MF.varTable.jets.cjTableSize then
+			local player = getPlayer(MF.playerIndex)
+			if player then
+				player.print({"info.cjTooManyGhosts", MF.varTable.jets.cjTableSize})
+			end
+			--global.constructionTable = {}
+		else
+			table.insert(global.constructionTable,{ent=cent, item=cent.ghost_prototype.items_to_place_this[1].name, name=cent.ghost_name, position=cent.position, direction=cent.direction or 1, mission="Construct"})
 		end
-		table.insert(global.constructionTable,{ent=cent, item=cent.ghost_prototype.items_to_place_this[1].name, name=cent.ghost_name, position=cent.position, direction=cent.direction or 1, mission="Construct"})
 	end
 
 	-- Clone the Entity if it is inside the Sync Area --

--- a/utils/saved-tables.lua
+++ b/utils/saved-tables.lua
@@ -1,3 +1,11 @@
+
+-- Apply Settings Stored in Ghost Tags --
+function objApplyTags(obj, tags)
+	if tags and valid(obj) and obj.tagsToSettings then
+		obj:tagsToSettings(tags)
+	end
+end
+
 -- Save the Dimensional Accumulator in a table --
 function placedDimensionalAccumulator(event)
 	if global.accTable == nil then global.accTable = {} end
@@ -13,7 +21,9 @@ end
 -- Save the Matter Interactor in a table --
 function placedMatterInteractor(event)
 	if global.matterInteractorTable == nil then global.matterInteractorTable = {} end
-	global.matterInteractorTable[event.created_entity.unit_number] = MI:new(event.created_entity)
+	local newMI = MI:new(event.created_entity)
+	global.matterInteractorTable[event.created_entity.unit_number] = newMI
+	objApplyTags(newMI, event.tags)
 end
 
 -- Save the Fluid Interactor in a table --
@@ -80,13 +90,17 @@ end
 -- Save the Deep Storage --
 function placedDeepStorage(event)
 	if global.deepStorageTable == nil then global.deepStorageTable = {} end
-	global.deepStorageTable[event.created_entity.unit_number] = DSR:new(event.created_entity)
+	local newDSR = DSR:new(event.created_entity)
+	global.deepStorageTable[event.created_entity.unit_number] = newDSR
+	objApplyTags(newDSR, event.tags)
 end
 
 -- Save the Deep Tank --
 function placedDeepTank(event)
 	if global.deepTankTable == nil then global.deepTankTable = {} end
-	global.deepTankTable[event.created_entity.unit_number] = DTK:new(event.created_entity)
+	local newDTK = DTK:new(event.created_entity)
+	global.deepTankTable[event.created_entity.unit_number] = newDTK
+	objApplyTags(newDTK, event.tags)
 end
 
 -- Save the Erya Structure --
@@ -94,8 +108,6 @@ function placedEryaStructure(event)
 	if global.eryaTable == nil then global.eryaTable  = {} end
 	global.eryaTable[event.created_entity.unit_number] = ES:new(event.created_entity)
 end
-
-
 
 -- Remove the Dimensional Accumulator from the table --
 function removedDimensionalAccumulator(event)


### PR DESCRIPTION
…eck tiles

blueprinting: write settings to ghost tags, and apply ghost tags if found with per-object functions when entity is built

self.mode was wrong copy/paste value, self.selectedMode is correct (fluid/matter interactor)

construction jets can place tiles. option to increase ghosts permitted in construction table (a global table! not good!) migration to add new option as MF.varTable.jets.cjTableSize

print a specific error message on init or reconfigure if we're missing tiles we need to be present: build, void, dim. and tutorial-grid. sync area tile is not necessary, so it was previously patched to grab any suitable grass/dirt