### PR TITLE
valid player - invalid gui, spelling fix, copypasting issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.0.137
+Date: 29/04/2020
+  BugFixes:
+    - Don't use an invalid GUI for a valid player
+    - find_non_colliding_position error (spelling)
+    - copy pasting multiple entities fix
+---------------------------------------------------------------------------------------------------
 Version: 0.0.136
 Date: 29/04/2020
   Corrections:

--- a/control.lua
+++ b/control.lua
@@ -234,18 +234,26 @@ local function onForceCreated(event)
 end
 
 local function onPlayerSetupBlueprint(event)
-  local player = game.players[event.player_index]
-  local mapping = event.mapping.get()
-  local bp = player.blueprint_to_setup
+	local player = game.players[event.player_index]
+	local mapping = event.mapping.get()
+	local bp = player.blueprint_to_setup
+	if bp.valid_for_read == false then
+		local cursor = player.cursor_stack
+		if cursor and cursor.valid_for_read and cursor.name == "blueprint" then
+			bp = cursor
+			--return
+		end
+	end
+	if bp == nil or bp.valid_for_read == false then return end
 
-  local nameToTable = {
-	["MatterInteractor"] = "matterInteractorTable",
-	["FluidInteractor"] = "fluidInteractorTable",
-	["WirelessDataReceiver"] = "wirelessDataReceiverTable",
-	["OreCleaner"] = "oreCleanerTable",
-	["DeepStorage"] = "deepStorageTable",
-	["DeepTank"] = "deepTankTable",
-  }
+	local nameToTable = {
+		["MatterInteractor"] = "matterInteractorTable",
+		["FluidInteractor"] = "fluidInteractorTable",
+		["WirelessDataReceiver"] = "wirelessDataReceiverTable",
+		["OreCleaner"] = "oreCleanerTable",
+		["DeepStorage"] = "deepStorageTable",
+		["DeepTank"] = "deepTankTable",
+	}
 
 	for index, ent in pairs(mapping) do
 		local saveTable = nameToTable[ent.name]

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "Mobile_Factory",
-	"version": "0.0.136",
+	"version": "0.0.137",
 	"title": "Mobile Factory",
 	"author": "Mugiwaxar",
 	"dependencies": ["base >= 0.18", "Mobile_Factory_Graphics >= 0.0.6"],

--- a/scripts/GUI/main-gui.lua
+++ b/scripts/GUI/main-gui.lua
@@ -7,9 +7,18 @@ function GUI.createMFMainGUI(player)
 	local playerIndex = player.index
 
 	if global.GUITable["MFMainGUI"..playerIndex] ~= nil then
-		posX = global.GUITable["MFMainGUI"..playerIndex].location.x
-		posY = global.GUITable["MFMainGUI"..playerIndex].location.y
-		visible = global.GUITable["MFMainGUI"..playerIndex].MFMainGUIFrame2.visible
+		if player.valid and global.GUITable["MFMainGUI"..playerIndex].valid then
+			posX = global.GUITable["MFMainGUI"..playerIndex].location.x
+			posY = global.GUITable["MFMainGUI"..playerIndex].location.y
+			visible = global.GUITable["MFMainGUI"..playerIndex].MFMainGUIFrame2.visible
+		else
+			--[[
+				Honktown - I believe a player being deleted and a new player with the same index caused a collision...
+					The player was valid (Assuming everyone in game.players is) but the gui object is not.
+			--]]
+			global.GUITable["MFMainGUI"..playerIndex] = nil
+			--return
+		end
 	end
 
 	-- Create the GUI --

--- a/utils/functions.lua
+++ b/utils/functions.lua
@@ -166,7 +166,7 @@ function mfPlaceable(player, MF)
 		return nil
 	end
 	-- Try to a position near the Player --
-	return player.surface.find_noncolliding_position(MF.ent.name, player.position, 10, 1, true)
+	return player.surface.find_non_colliding_position(MF.ent.name, player.position, 10, 1, true)
 --[[
 	-- Try to a position near the Player --
 	if player.surface.can_place_entity{name=MF.ent.name, position={player.position.x+5, player.position.y}} == false then


### PR DESCRIPTION
If a player is deleted but a new player has the same index, it will cause a collision with existing stored data (what likely happened)

find_non_colliding_position, not find_noncolliding_position

copy-pasting multiple entities triggers the blueprint event, but the blueprint is in the cursor (is not in blueprint_to_setup)