### PR TITLE
energy laser rotation, minimum transfer, slight locale editing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.0.164
+Date: 15/05/2020
+  Changes:
+    - decrease Energy Laser power consumption statistics (related to Factorio bug)
+  Bugfixes:
+    - Energy Laser can be rotated
+---------------------------------------------------------------------------------------------------
 Version: 0.0.163
 Date: 15/05/2020
   Changes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "Mobile_Factory",
-	"version": "0.0.163",
+	"version": "0.0.164",
 	"title": "Mobile Factory",
 	"author": "Mugiwaxar",
 	"dependencies": ["base >= 0.18", "Mobile_Factory_Graphics >= 0.0.7"],

--- a/locale/en/config.cfg
+++ b/locale/en/config.cfg
@@ -95,7 +95,7 @@ FluidExtractor=Use Quatron Charge to extract Fluid
 InternalEnergyCube=Your Mobile Factory Battery (Can be placed once inside the Mobile Factory)
 InternalQuatronCube=Your Mobile Factory Quatron Battery (Can be placed once inside the Mobile Factory)
 EnergyCubeMK1=An Energy Cube that can store 100MJ of Energy and powers Circuit Networks when circuit-connected
-EnergyLaser1=Placed next to an Energy Cube, the Energy Laser MK1 can move [color=yellow]5MJ/s[/color] of Energy to the focused compatible Structure (Energy Cubes, Power Lasers, Mobile Factory ... )
+EnergyLaser1=Placed against an Energy Cube, the Energy Laser MK1 can move [color=yellow]5MJ/s[/color] of Energy to the focused compatible Structure (Energy Cubes, Energy Lasers, Mobile Factory ... )
 WirelessDataTransmitter=Distribute the connected Data Network to far-away links (bidirectional)
 WirelessDataReceiver=Access far-away Network (take, give). Receives Network Power from the connection and acts as a Data Center.
 TempChest=Just a casual temporary Chest
@@ -318,7 +318,7 @@ InternalQuatronCube=Your Mobile Factory Quatron Battery (Can be placed once insi
 EnergyCubeMK1=An Energy Cube that can store 100MJ of Energy and powers Circuit Networks when circuit-connected
 EnergyCubeC=\n[color=purple]Energy:[/color] __1__
 QuatronCubeC=\n[color=purple]Quatron:[/color] __1__
-EnergyLaser1=Placed next to an Energy Cube, the Energy Laser MK1 can move [color=yellow]5MJ/s[/color] of Energy to the focused compatible Structure (Energy Cubes, Power Lasers, Mobile Factory ... )
+EnergyLaser1=Placed against an Energy Cube, the Energy Laser MK1 can move [color=yellow]5MJ/s[/color] of Energy to the focused compatible Structure (Energy Cubes, Energy Lasers, Mobile Factory ... )
 WirelessDataTransmitter=Distribute the connected Data Network to far-away links (bidirectional)
 WirelessDataReceiver=Access far-away Network (take, give). Receives Network Power from the connection and acts as a Data Center.
 DimensionalWire=Wire made from Dimensional Plate
@@ -817,6 +817,7 @@ InputTT=Send Item/Fluid to the selected Inventory
 Output=Output
 OutputTT=Retrieve Item/Fluid from the selected Inventory
 PowerLaser=Power Lasers
+EnergyLaser=Energy Lasers
 FluidLaser=Fluid Lasers
 MSPlayerTarget=Player
 MSTarget=Targeted Inventory

--- a/prototypes/entity/energy-laser.lua
+++ b/prototypes/entity/energy-laser.lua
@@ -62,13 +62,27 @@ elE.energy_source =
     type = "electric",
     usage_priority = "secondary-input",
     buffer_capacity = "5MJ",
-    output_flow_limit = "1J",
-    input_flow_limit = "1J",
+    output_flow_limit = "0.0001W",
+    input_flow_limit = "0.0001W",
     drain = "0J",
     render_no_power_icon = false,
     render_no_network_icon = false
 }
 elE.energy_usage = "5MJ"
+elE.fluid_boxes = {
+    {
+        base_level = 1,
+        pipe_connections = {
+            {
+                position = {
+                    0,
+                    -1
+                }
+            }
+        },
+        production_type = "output",
+    }
+}
 data:extend{elE}
 
 -- Item --

--- a/scripts/objects/energy-laser.lua
+++ b/scripts/objects/energy-laser.lua
@@ -138,8 +138,6 @@ function EL:sendEnergy()
 		self.ent.surface.create_entity{name="MK1SendBeam", duration=5, position= EL.getBeamPositionA(self), target_position=EL.getBeamPositionB(self), source=EL.getBeamPositionA(self)}
 		self.beam = self.ent.surface.create_entity{name="MK1ConnectedBeam", position= EL.getBeamPositionA(self), target_position=EL.getBeamPositionB(self), source=EL.getBeamPositionA(self)}
 	end
-
-
 end
 
 -- Look for an Entity to recharge --
@@ -179,7 +177,8 @@ end
 -- Return the amount of Energy --
 function EL:energy()
 	if self.ent ~= nil and self.ent.valid == true then
-		if self.ent.energy < 1000 then self.ent.energy = 0 end
+		-- Only Act If EL Has More Than 100 kJ -- 
+		if self.ent.energy < 1e5 then return 0 end
 		return self.ent.energy
 	end
 	return 0


### PR DESCRIPTION
an assembling machine has specific rules on what makes it rotate-able. simplest to add was an output fluidbox pointing in direction of laser.

don't discard < 1000 joules, instead, have a minimum transfer of 100kJ

Decrease prototype flow from 60 W (1J * 60 ticks/s) to 0.0001W