### PR TITLE
begin mining flag ore scan cleanup, mf double-invalid entities fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.0.185
+Date: 11/06/2020
+  Changes:
+    - Begin some mining jet flag optimizations
+  Bugfixes:
+    - double-invalid MF sync entity causing error on update
+---------------------------------------------------------------------------------------------------
 Version: 0.0.184
 Date: 10/06/2020
   Changes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "Mobile_Factory",
-	"version": "0.0.184",
+	"version": "0.0.185",
 	"title": "Mobile Factory",
 	"author": "Mugiwaxar",
 	"dependencies": ["base >= 0.18", "Mobile_Factory_Graphics >= 0.0.9"],

--- a/scripts/objects/mining-jet-flag.lua
+++ b/scripts/objects/mining-jet-flag.lua
@@ -208,7 +208,7 @@ function MJF:scanOres()
 	-- Remove Fluid Path from the Table --
 	for k, path in pairs(self.oreTable) do
 		if path.prototype.mineable_properties.products[1].type ~= "item" then
-			self.oreTable[k] = nil
+			table.remove(self.oreTable, k)
 		end
 	end
 	
@@ -221,11 +221,9 @@ function MJF:getOrePath()
 	local i = math.random(1, table_size(self.oreTable))
 	local orePath = self.oreTable[i]
 	if orePath == nil then
-		for k, path in pairs(self.oreTable) do
-			if path ~= nil and path.valid == true then return path end
-			if path ~= nil and path.valid == false then self:removeOrePath(path) end
-		end
+		self:removeOrePath(orePath)
 	elseif orePath.valid == false then
+		self.oreTable[i] = nil
 		self:removeOrePath(orePath)
 	else
 		return orePath
@@ -233,17 +231,19 @@ function MJF:getOrePath()
 	return nil
 end
 
--- Remove an Ore Path from the Ore Table --
+-- Remove invalid Ore Paths from the Ore Table --
 function MJF:removeOrePath(orePath)
 	for k, path in pairs(self.oreTable) do
-		if path == orePath then
-			if table_size(self.oreTable) <= 1 then
-				self.oreTable = {}
-			else
-				table.remove(self.oreTable, k)
-			end
-			
+		if path.valid == false then self.oreTable[k] = nil end
+	end
+	if #self.oreTable ~= table_size(self.oreTable) then
+		local oreArray = {}
+		local i = 1
+		for _, path in pairs(self.oreTable) do
+			oreArray[i] = path
+			i = i + 1
 		end
+		self.oreTable = oreArray
 	end
 end
 

--- a/scripts/objects/mobile-factory.lua
+++ b/scripts/objects/mobile-factory.lua
@@ -1075,7 +1075,7 @@ function MF:updateClonedEntities()
 	for i, ents in pairs(self.clonedResourcesTable) do
 		self:updateClonedEntity(ents)
 		if ents.original == nil or ents.original.valid == false then
-			-- only checking original because both are invalid after updating
+			-- only checking original because both are nil/invalid after updating
 			table.remove(self.clonedResourcesTable, i)
 		end
 	end
@@ -1086,13 +1086,15 @@ function MF:updateClonedEntity(ents)
 	-- Check the Entities --
 	if ents == nil then return end
 	if ents.original == nil or ents.original.valid == false then
-		script.raise_event(defines.events.script_raised_destroy, {entity=ents.cloned})
-		ents.cloned.destroy()
+		if ents.cloned ~= nil and ents.cloned.valid == true then
+			ents.cloned.destroy({raise_destroy = true})
+		end
 		return
 	end
 	if ents.cloned == nil or ents.cloned.valid == false then
-		script.raise_event(defines.events.script_raised_destroy, {entity=ents.original})
-		ents.original.destroy()
+		if ents.original ~= nil and ents.original.valid == true then
+			ents.original.destroy({raise_destroy = true})
+		end
 		return
 	end
 	if ents.original.type == "resource" then


### PR DESCRIPTION
mining flag used to make holes and other not-great behavior when ore paths were mined. started clean-up and improvement of code

mf sync entities could become invalid on both sides without being removed... somehow, throwing a sync error.