### PR TITLE
Various tweaks and fixes to DA

### DIFF
--- a/locale/en/config.cfg
+++ b/locale/en/config.cfg
@@ -525,7 +525,7 @@ MFUnlocked=The Mobile Factory is Unlocked, anyone can enter
 TPNoDriver=The Mobile Factory can't teleport without a Driver
 TPObstruction=Unable to Teleport here, obstruction detected!
 TPSurfaceNoFound=The targeted surface doesn't exist anymore
-
+DAWrongRecipe=This recipe is not available
 
 ## ---- MAIN ---- ##
 mfPosition=Position
@@ -698,6 +698,7 @@ QuatronCharge=Quatron Charge
 DataAssemblerText1=Right Click a Recipe to remove it
 DataAssemblerText2=Data Assembler use Quatron to work
 DataAssemblerText3=Quatron is taken from Internal Inventory
+DataAssemblerText4=Left Click a Product to prioritize it
 
 ## ---- DATA NETWORK ---- ##
 DataNetwork=Data Network

--- a/migrations/0.0.a193to0.0.194.lua
+++ b/migrations/0.0.a193to0.0.194.lua
@@ -1,0 +1,34 @@
+for _, da in pairs(global.dataAssemblerTable or {}) do
+	for id, recipe in pairs(da.recipeTable or {}) do
+		local recipePrototype = recipe.recipePrototype
+		recipe.mainProduct = nil
+		recipe.products = {}
+		-- Update products
+		for _, product in ipairs(recipePrototype.products) do
+			if game.item_prototypes[product.name] ~= nil then
+				table.insert(recipe.products, {name=product.name, type=product.type, amount=product.amount, probability = product.probability or 1,sprite="item/" .. product.name, tooltip=game.item_prototypes[product.name].localised_name})
+			elseif game.fluid_prototypes[product.name] ~= nil then
+				table.insert(recipe.products, {name=product.name, type=product.type, amount=product.amount, probability = product.probability or 1, sprite="fluid/" .. product.name, tooltip=game.fluid_prototypes[product.name].localised_name})
+			end
+		end
+		-- Select default main product
+		if recipePrototype.main_product ~= nil and recipePrototype.main_product.name ~= recipe.products[1].name then
+			for idx, product in ipairs(recipe.products) do
+				if product.name == recipePrototype.main_product.name then
+					products[1], products[idx] = products[idx], products[1]
+					break
+				end
+			end
+		end
+		-- Add tooltips to ingredients
+		for _, ingredient in ipairs(recipe.ingredients) do
+			if game.item_prototypes[ingredient.name] ~= nil then
+				ingredient.tooltip = game.item_prototypes[ingredient.name].localised_name
+			elseif game.fluid_prototypes[ingredient.name] ~= nil then
+				ingredient.tooltip = game.fluid_prototypes[ingredient.name].localised_name
+			else
+				ingredient.tooltip = ""
+			end
+		end
+	end
+end

--- a/scripts/GUI/gui.lua
+++ b/scripts/GUI/gui.lua
@@ -509,6 +509,15 @@ function GUI.buttonClicked(event)
 			if valid(obj) == false then return end
 			obj:removeRecipe(recipeID)
 		end
+		if string.match(event.element.name, "DASwap") then
+			local objID = tonumber(split(event.element.name, ",")[2])
+			local obj = global.dataAssemblerTable[objID]
+			local recipeID = tonumber(split(event.element.name, ",")[3])
+			local productID = tonumber(split(event.element.name, ",")[4])
+			if valid(obj) == false then return end
+			local products = obj.recipeTable[recipeID].products
+			products[1], products[productID] = products[productID], products[1]
+		end
 		-- Update all GUIs --
 		GUI.updateAllGUIs(true)
 		return

--- a/scripts/objects/data-assembler.lua
+++ b/scripts/objects/data-assembler.lua
@@ -252,7 +252,7 @@ function DA:createFrame(GUIObj, gui, recipe, id)
 	end
 	local tooltip = (recipe.amount or 0) > 0 and {"", recipe.recipePrototype.localised_name, " (max:", recipe.amount, ")"} or recipe.recipePrototype.localised_name
 	local recipeButton = GUIObj:addButton("DARem," .. self.entID .. "," .. id, recipeFlow, recipe.sprite, recipe.sprite, tooltip, 50, false, true, recipe.amount)
-	recipeButton.style = recipe.toManyInInventory == true and "MF_Fake_Button_Red" or "MF_Fake_Button_Green"
+	recipeButton.style = (recipe.toManyInInventory == true and "MF_Fake_Button_Red") or "MF_Fake_Button_Green"
 	recipeButton.style.padding = 0
 	recipeButton.style.margin = 0
 
@@ -265,25 +265,25 @@ function DA:createFrame(GUIObj, gui, recipe, id)
 
 	-- Add all Buttons --
 	for k, ingredient in pairs(recipe.ingredients) do
-		if game.item_prototypes[ingredient.name] == nil and game.fluid_prototypes[ingredient.name] == nil then
+		if (game.item_prototypes[ingredient.name] == nil) and (game.fluid_prototypes[ingredient.name] == nil) then
 			self.recipeTable[id] = nil
 			return
 		end
-		local storedAmount = ingredient.type == "item" and self.dataNetwork:hasItem(ingredient.name) or self.dataNetwork:hasFluid(ingredient.name)
+		local storedAmount = (ingredient.type == "item" and self.dataNetwork:hasItem(ingredient.name)) or self.dataNetwork:hasFluid(ingredient.name)
 		local ingredientButton = GUIObj:addButton("", ingredientsFlow, ingredient.sprite, ingredient.sprite, ingredient.tooltip, 30, false, true, storedAmount or 0)
-		ingredientButton.style = ingredient.missing == true and "MF_Fake_Button_Red" or "MF_Fake_Button_Green"
+		ingredientButton.style = (ingredient.missing == true and "MF_Fake_Button_Red") or "MF_Fake_Button_Green"
 		ingredientButton.style.padding = 0
 		ingredientButton.style.margin = 0
 	end
 
 	-- Create the Progress Bar --
-	local barColor = (self.quatronCharge > 0 and self.active == true ) and _mfGreen or _mfRed
+	local barColor = ((self.quatronCharge > 0 and self.active == true) and _mfGreen) or _mfRed
 	local PBar = GUIObj:addProgressBar("", processFlow, "", "", false, barColor, recipe.progress / recipe.recipePrototype.energy, 150)
 	if GUIObj.PBarsTable == nil then GUIObj.PBarsTable = {} end
 	GUIObj.PBarsTable[PBar] = recipe
 
 	-- Check the Product --
-	if game.item_prototypes[recipe.products[1].name] == nil and game.fluid_prototypes[recipe.products[1].name] == nil then
+	if (game.item_prototypes[recipe.products[1].name] == nil) and (game.fluid_prototypes[recipe.products[1].name] == nil) then
 		self.recipeTable[id] = nil
 		return
 	end
@@ -295,7 +295,7 @@ function DA:createFrame(GUIObj, gui, recipe, id)
 	for key, product in ipairs(recipe.products) do
 		local storedAmount = product.type == "item" and self.dataNetwork:hasItem(product.name) or self.dataNetwork:hasFluid(product.name)
 		local productButton = GUIObj:addButton("DASwap," .. self.entID .. "," .. id .. "," .. key, resultFlow, product.sprite, product.sprite, product.tooltip, 50, false, true, storedAmount or 0)
-		productButton.style = recipe.inventoryFull == true and "MF_Fake_Button_Red" or "MF_Fake_Button_Green"
+		productButton.style = (recipe.inventoryFull == true and "MF_Fake_Button_Red") or "MF_Fake_Button_Green"
 		productButton.style.padding = 0
 		productButton.style.margin = 0
 	end
@@ -303,7 +303,7 @@ end
 
 -- Update all Progress Bars --
 function DA:updatePBars(GUIObj)
-	local barColor = (self.quatronCharge > 0 and self.active == true ) and _mfGreen or _mfRed
+	local barColor = ((self.quatronCharge > 0 and self.active == true) and _mfGreen) or _mfRed
 	for PBar, recipe in pairs(GUIObj.PBarsTable or {}) do
 		if valid(PBar) == true and recipe ~= nil then
 			PBar.value = recipe.progress / recipe.recipePrototype.energy


### PR DESCRIPTION
DA gives all products of recipe, and properly checking probability when it needed.
Tweaked GUI a bit to represent that - now it show icons of all items. Left product is "main", it's the one which amount is checked when DA consider whether it need to craft recipe some more, or it's time to stop. Player can select any other product as "main" by simply clicking it.
Recipes locked by techs, admin-only and such is not available to select anymore.
Added some missing tooltips. 
Check for non-numerical amount in recipes actually works now.
Migration script from older versions provided.
