### PR TITLE
Random fixes

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -192,6 +192,7 @@ end
 script.on_init(onInit)
 script.on_configuration_changed(onInit)
 script.on_load(onLoad)
+script.on_event(defines.events.on_cutscene_cancelled, initPlayer)
 script.on_event(defines.events.on_player_created, initPlayer)
 script.on_event(defines.events.on_player_joined_game, initPlayer)
 script.on_event(defines.events.on_player_driving_changed_state, playerDriveStatChange)

--- a/scripts/GUI/gui.lua
+++ b/scripts/GUI/gui.lua
@@ -107,7 +107,7 @@ function GUI.guiOpened(event)
 	-- do not open custom GUI if player is connecting wires --
 	local cursorStack = player.cursor_stack
 	if cursorStack and cursorStack.valid_for_read then
-		if cursorStack.name == "green-wire" or cursorStack.name == "red-wire" then return end
+		if cursorStack.name == "green-wire" or cursorStack.name == "red-wire" or cursorStack.type == "repair-tool" then return end
 	end
 
 	-- Check the Bypass --

--- a/scripts/game-update.lua
+++ b/scripts/game-update.lua
@@ -79,6 +79,7 @@ end
 -- When a player join the game --
 function initPlayer(event)
 	local player = getPlayer(event.player_index)
+	if player.controller_type == defines.controllers.cutscene then return end
 	if player == nil then return end
 	--player.force.technologies["DimensionalOre"].researched = true
 	if getMFPlayer(player.name) == nil then
@@ -89,7 +90,7 @@ function initPlayer(event)
 		createControlRoom(MF)
 		global.playersTable[player.name].MF = MF
 		------------------- Can't get the Player Inventory when the Mod Init since the Factorio 1.0 Version -------------------
-		-- Util.addMobileFactory(player)
+		Util.addMobileFactory(player)
 		setPlayerVariable(player.name, "GotInventory", true)
 		GUI.createMFMainGUI(player)
 		

--- a/scripts/game-update.lua
+++ b/scripts/game-update.lua
@@ -97,6 +97,10 @@ function initPlayer(event)
 			remote.call("dangOreus","toggle",MF.fS)
 			remote.call("dangOreus","toggle",MF.ccS)
 		end
+		if remote.interfaces["RSO"] then
+			remote.call("RSO","ignoreSurface",MF.fS.name)
+			remote.call("RSO","ignoreSurface",MF.ccS.name)
+		end
 	end
 end
 

--- a/scripts/objects/internal-energy.lua
+++ b/scripts/objects/internal-energy.lua
@@ -34,7 +34,7 @@ function IEC:setEnt(object)
 	self.spriteID = rendering.draw_sprite{sprite="EnergyCubeMK1Sprite0", x_scale=1/2.25, y_scale=1/2.25, target=object, surface=object.surface, render_layer=130}
 	self.lightID = rendering.draw_light{sprite="EnergyCubeMK1Sprite0", scale=1/2.25, target=object, surface=object.surface, minimum_darkness=0}
 	-- Update the UpSys --
-	-- UpSys.scanObjs() -- Make old save crash --
+	UpSys.scanObjs() -- Make old save crash --
 end
 
 -- Reconstructor --

--- a/scripts/objects/internal-energy.lua
+++ b/scripts/objects/internal-energy.lua
@@ -34,7 +34,8 @@ function IEC:setEnt(object)
 	self.spriteID = rendering.draw_sprite{sprite="EnergyCubeMK1Sprite0", x_scale=1/2.25, y_scale=1/2.25, target=object, surface=object.surface, render_layer=130}
 	self.lightID = rendering.draw_light{sprite="EnergyCubeMK1Sprite0", scale=1/2.25, target=object, surface=object.surface, minimum_darkness=0}
 	-- Update the UpSys --
-	UpSys.scanObjs() -- Make old save crash --
+	--UpSys.scanObjs() -- Make old save crash --
+	UpSys.addObject(self)
 end
 
 -- Reconstructor --

--- a/scripts/objects/internal-quatron.lua
+++ b/scripts/objects/internal-quatron.lua
@@ -34,7 +34,8 @@ function IQC:setEnt(object)
 	self.spriteID = rendering.draw_sprite{sprite="QuatronCubeSprite0", x_scale=1/2.25, y_scale=1/2.25, target=object, surface=object.surface, render_layer=130}
 	self.lightID = rendering.draw_light{sprite="QuatronCubeSprite0", scale=1/2.25, target=object, surface=object.surface, minimum_darkness=0}
 	-- Update the UpSys --
-	UpSys.scanObjs() -- Make old save crash --
+	--UpSys.scanObjs() -- Make old save crash --
+	UpSys.addObject(self)
 end
 
 -- Reconstructor --

--- a/scripts/objects/internal-quatron.lua
+++ b/scripts/objects/internal-quatron.lua
@@ -34,7 +34,7 @@ function IQC:setEnt(object)
 	self.spriteID = rendering.draw_sprite{sprite="QuatronCubeSprite0", x_scale=1/2.25, y_scale=1/2.25, target=object, surface=object.surface, render_layer=130}
 	self.lightID = rendering.draw_light{sprite="QuatronCubeSprite0", scale=1/2.25, target=object, surface=object.surface, minimum_darkness=0}
 	-- Update the UpSys --
-	-- UpSys.scanObjs() -- Make old save crash --
+	UpSys.scanObjs() -- Make old save crash --
 end
 
 -- Reconstructor --


### PR DESCRIPTION
https://github.com/Mugiwaxar/Mobile-Factory/commit/54371b50c8f78405b622bcb4a557bb6d6bec707a Repair kits added to GUI exclusions list, so player can repair his custom entities.
https://github.com/Mugiwaxar/Mobile-Factory/commit/4e8f6e360393653a1fe385f2a905a9ec277abd11 Restored UpSys.scanObjs() of cubes, as they can lose tags if not tracked. I sincerely have no idea what the deal with "old saves crash", but now it actually needed. It's in separate commit, so you can revert that if it really that important.
https://github.com/Mugiwaxar/Mobile-Factory/commit/4856060ef06cb5d4c4c8b790676c854cd7d39489 MF surfaces ignored by RSO, to prevent possible weirdness.
https://github.com/Mugiwaxar/Mobile-Factory/commit/4522fcc4e9062500745068cafc912a1ff8e2701e Fixed premature initializations. Without relying on freeplay remotes. initPlayer() fires *both* on starting game, and canceling\ending cutscene. If game starts on cutscene we're skiping first initialization, assuming that cutscene will eventually be over. And then init fires agan, and does all his stuff - give items, create surfaces.