### PR TITLE
0.0.197 related pre-patching

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,14 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.0.197
+Date: 26/09/2020
+  Features:
+    - Blueprinting is back, baby! (thanks Volch! - honk honk)
+  Bugfixes:
+    - error when a resource catcher is destroyed
+    - workaround to prevent storing an item-with-tags, as tags are forgotten
+           only applies when user interface is open (existing matter interactors aren't changed)
+           may have bugs, please report
+---------------------------------------------------------------------------------------------------
 Version: 0.0.196
 Date: 23/09/2020
   Bugfixes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "Mobile_Factory",
-	"version": "0.0.196",
+	"version": "0.0.197",
 	"title": "Mobile Factory",
 	"author": "Mugiwaxar",
 	"dependencies": ["base >= 1.0", "Mobile_Factory_Graphics >= 0.0.12"],

--- a/scripts/objects/gui-object.lua
+++ b/scripts/objects/gui-object.lua
@@ -522,6 +522,7 @@ function createPlayerInventoryFrame(GUIObj, gui, MFPlayer, columnsNumber, button
     for name, count in pairs(MFPlayer.ent.get_main_inventory().get_contents()) do
         -- Check the Item --
         if name == nil or count == nil or count == 0 or game.item_prototypes[name] == nil then goto continue  end
+        if game.item_prototypes[name].type == "item-with-tags" then goto continue end --workaround, tags could be recorded but as of 0.0.197 are forgotten
         -- Check the Filter --
         if MFPlayer.varTable.tmpLocal ~= nil and Util.getLocItemName(name)[1] ~= nil then
             local locName = MFPlayer.varTable.tmpLocal[Util.getLocItemName(name)[1]]

--- a/scripts/objects/matter-interactor.lua
+++ b/scripts/objects/matter-interactor.lua
@@ -158,6 +158,17 @@ function MI:getTooltipInfos(GUIObj, gui, justCreated)
 	if self.selectedMode == "output" then state = "right" end
 	GUIObj:addSwitch("MIMode" .. self.ent.unit_number, titleFrame, {"gui-description.Input"}, {"gui-description.Output"}, {"gui-description.InputTT"}, {"gui-description.OutputTT"}, state)
 
+	--prevent item-with-tags from being stored, allow retrieval (0.0.197+) - workaround until we record tags
+	if self.selectedMode == "input"
+			and filter.elem_value ~= nil
+			and game.item_prototypes[filter.elem_value].type == "item-with-tags"
+		then
+		game.print("Inputing an item-with-tags ([item="..filter.elem_value.."]) erases tags (dangerous!). Clearing Matter Interactor values.")
+		filter.elem_value = nil
+		self.selectedFilter = nil
+		self.selectedInv = nil --may not be necessary? assigning anyway
+	end
+
 	-- Create the Inventory Selection --
 	GUIObj:addLabel("", titleFrame, {"gui-description.MSTarget"}, _mfOrange)
 


### PR DESCRIPTION
changelog and info
resource catcher destroy'd patch
initial code to prevent items-with-tags from being stored as a stopgap for losing tags