### PR TITLE
Prevent migrations from running on fresh install

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -43,6 +43,10 @@ require("scripts/objects/resource-catcher.lua")
 -- When the mod init --
 function onInit()
 
+	-- Check if mod being initialized for the very first time
+	-- This *need* to be at the very begginng of on_init callback
+	global.allowMigration = ( next(global) ~= nil )
+
 	-- Update System --
 	global.entsTable = global.entsTable or {}
 	global.upsysTickTable = global.upsysTickTable or {}

--- a/migrations/0.0.0.oldMigrations.lua
+++ b/migrations/0.0.0.oldMigrations.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- To OOP --
 if global.MobileFactory ~= nil then
 	global.MF = MF:new()

--- a/migrations/0.0.91to0.0.92b.lua
+++ b/migrations/0.0.91to0.0.92b.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Clear Data Network --
 for k, DN in pairs(global.dataNetworkTable or {}) do
 	DN.GCNTable = nil

--- a/migrations/0.0.92to0.0.93.lua
+++ b/migrations/0.0.92to0.0.93.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Create Signals Tables --
 for k, DN in pairs(global.dataNetworkTable or {}) do
 	DN.signalsTable = {}

--- a/migrations/0.0.93to0.0.94.lua
+++ b/migrations/0.0.93to0.0.94.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Clear Wireless Data Transmitters Signals --
 for k, DT in pairs(global.wirelessDataTransmitterTable or {}) do
 	DT.lastSignal = {}

--- a/migrations/0.0.97to0.0.98d.lua
+++ b/migrations/0.0.97to0.0.98d.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Set all Mobile Factory Objects to belongs to the first Player --
 local player = nil
 global.MFTable = {}

--- a/migrations/0.0.99to0.0.100.lua
+++ b/migrations/0.0.99to0.0.100.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Set last user and Force for the default created Entities inside the Mobile Factory --
 for k, MF in pairs(global.MFTable) do
     if MF.fChest ~= nil and MF.fChest.valid == true then

--- a/migrations/0.0.a101to0.0.102.lua
+++ b/migrations/0.0.a101to0.0.102.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Create a MF object and MFPlayer Object for every Players and set the Beginning Technology to unlocked --
 if global.playersTable == nil then global.playersTable = {} end
 if global.MFTable == nil then global.MFTable = {} end

--- a/migrations/0.0.a105to0.0.106.lua
+++ b/migrations/0.0.a105to0.0.106.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 for k, MF in pairs(global.MFTable) do
     -- Unlock the Control Center Area --
     if technologyUnlocked("ControlCenter") then

--- a/migrations/0.0.a106to0.0.107.lua
+++ b/migrations/0.0.a106to0.0.107.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Recreate the Control Center Teleportation Floor --
 for k, MF in pairs(global.MFTable) do
     local tilesTable = {}

--- a/migrations/0.0.a107to0.0.108.lua
+++ b/migrations/0.0.a107to0.0.108.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Save Internal Data Center inside MF object --
 for k, dcmf in pairs(global.dataCenterTable or {}) do
 	if dcmf.invObj.isII and dcmf.ent.last_user.name ~= nil then

--- a/migrations/0.0.a108to0.0.109.lua
+++ b/migrations/0.0.a108to0.0.109.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Set all Factory surfaces to day/night cycle --
 for k, MF in pairs(global.MFTable) do
     if MF.fS ~= nil then

--- a/migrations/0.0.a114to0.0.115b.lua
+++ b/migrations/0.0.a114to0.0.115b.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Convert Dimensional Tanks to Deep Tank and create the Constructible Area --
 global.deepTankTable = {}
 for k, MF in pairs(global.MFTable) do

--- a/migrations/0.0.a115to0.0.116.lua
+++ b/migrations/0.0.a115to0.0.116.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Surfaces readjustment --
 for k, MF in pairs(global.MFTable or {}) do
     -- Create the Sync Area inside the Factory --

--- a/migrations/0.0.a117to0.0.118.lua
+++ b/migrations/0.0.a117to0.0.118.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Remove old GUIs --
 for k, player in pairs(game.players) do
     if player.gui.screen.mfGUI ~= nil then player.gui.screen.mfGUI.destroy() end

--- a/migrations/0.0.a125to0.0.126.lua
+++ b/migrations/0.0.a125to0.0.126.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 local key = nil
 local MFPlayer = nil
 local GUIObj = nil

--- a/migrations/0.0.a141to0.0.142.lua
+++ b/migrations/0.0.a141to0.0.142.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 for _, MF in pairs(global.MFTable) do
 	if MF.playerIndex == nil then
 		player = getPlayer(MF.player)

--- a/migrations/0.0.a145to0.0.146.lua
+++ b/migrations/0.0.a145to0.0.146.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 if global.matterInteractorTable == nil then return end
 
 for _, MI in pairs(global.matterInteractorTable) do

--- a/migrations/0.0.a154to0.0.155.lua
+++ b/migrations/0.0.a154to0.0.155.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Store GUI inside MFPlayer --
 for k, GUI in pairs(global.GUITable or {}) do
     -- Fix the Type error --

--- a/migrations/0.0.a155to0.0.156.lua
+++ b/migrations/0.0.a155to0.0.156.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Remove old MF Variables and create the Share Table --
 for k, MF in pairs(global.MFTable or {}) do
     MF.varTable.shareStructures = nil

--- a/migrations/0.0.a157to0.0.158.lua
+++ b/migrations/0.0.a157to0.0.158.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Re-create the Share Table (was not inited previous version) --
 for k, MF in pairs(global.MFTable) do
     MF.varTable.allowedPlayers = MF.varTable.allowedPlayers or {}

--- a/migrations/0.0.a159to0.0.160.lua
+++ b/migrations/0.0.a159to0.0.160.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Place the Internal Energy/Quatron Cube inside the Control Center --
 for k, MF in pairs(global.MFTable or {}) do
     if MF.ccS == nil then

--- a/migrations/0.0.a166to0.0.167.lua
+++ b/migrations/0.0.a166to0.0.167.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Add Cell to Quatron recipe --
 unlockRecipeForAll("CellToLiquidQuatron1", "Quatron")
 unlockRecipeForAll("CellToLiquidQuatron2", "Quatron")

--- a/migrations/0.0.a171to0.0.172.lua
+++ b/migrations/0.0.a171to0.0.172.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Fix all Energy Cubes Energy --
 for k, cube in pairs(global.energyCubesTable or {}) do
     if cube.ent ~= nil and cube.ent.valid == true and cube.ent.energy > cube.ent.electric_buffer_size then

--- a/migrations/0.0.a175to0.0.176.lua
+++ b/migrations/0.0.a175to0.0.176.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Add the Data Network to all Data Assemblers --
 for k, ds in pairs(global.dataStorageTable or {}) do
     ds.dataNetwork = ds.MF.dataNetwork

--- a/migrations/0.0.a176to0.0.177.lua
+++ b/migrations/0.0.a176to0.0.177.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Reset MF to all Internal Quatron Cube --
 for k, MF in pairs(global.MFTable) do
     MF.internalQuatronObj.MF = MF

--- a/migrations/0.0.a180to0.0.181.lua
+++ b/migrations/0.0.a180to0.0.181.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Create the Jump Drive Object --
 for k, mf in pairs(global.MFTable or {}) do
     mf.jumpDriveObj = JD:new(mf)

--- a/migrations/0.0.a188to0.0.189.lua
+++ b/migrations/0.0.a188to0.0.189.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 -- Print Erya Tech message --
 game.print("Erya Tech and Jets was removed from the Mobile Factory base Mod")
 game.print("The Erya Tech and Jets are now Extensions of Mobile Factory and must be downloaded before loading the save if you don't want to lose stuff")

--- a/migrations/0.0.a193to0.0.194.lua
+++ b/migrations/0.0.a193to0.0.194.lua
@@ -1,3 +1,4 @@
+if not global.allowMigration then return end
 for _, da in pairs(global.dataAssemblerTable or {}) do
 	for id, recipe in pairs(da.recipeTable or {}) do
 		local recipePrototype = recipe.recipePrototype


### PR DESCRIPTION
Here's the issue:
When mod run on scenario map or, more importantly, added to existing save, instead of creating new world, game applies all migrations scripts. And this huge pile of old code not always designed to harmlessly be runned on world which don't need to be migrated. And that does lead to problems.
Solution: 
on_init it's a single piece of mod which runs before migration, we're checking whether global is empty - and if it is, we know mod never was ran before, thus it's fresh install, thus we don't need migration to happens. And when on_init will be called again(infact - even sooner, since onInit also triggered by on_configuration_changed, which happens after migrations) we'll allow migrations again for the lifetime of mod, as global won't be ever empty again.