### PR TITLE
Blacklisting crafting categories

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -52,6 +52,7 @@ function onInit()
 	global.useVanillaChooseElem = global.useVanillaChooseElem or false
 	-- Data Network --
 	global.dataNetworkID = global.dataNetworkID or 0
+	global.dataAssemblerBlacklist = global.dataAssemblerBlacklist or {}
 	-- Floor Is Lava --
 	global.floorIsLavaActivated = global.floorIsLavaActivated or false
 	-- Research --

--- a/locale/en/config.cfg
+++ b/locale/en/config.cfg
@@ -604,6 +604,8 @@ GameTab=Game
 FloorIsLavaTitle=Floor Is Lava
 FloorIsLavaOpt=Active Floor Is Lava
 FloorIsLavaOptTT=The radioactivity is very strong, and the floor will damage you. Only the Dimensional Tile can save you from imminent death. (Admin only)
+DABlacklistLabel=Blacklisted crafting categories:
+DABlacklistLabelTT=Add or Remove Crafting Category that won't be allowed to craft in Data Assembler
 ## System Tab ##
 SystemTab=System
 PerfOpt=Performances

--- a/scripts/GUI/option-gui.lua
+++ b/scripts/GUI/option-gui.lua
@@ -163,6 +163,27 @@ function GUI.updateOptionGUIGameTab(GUIObj)
 	GUI.addOption("", scrollPane, "title", false, {text={"gui-description.FloorIsLavaTitle"}}, playerIndex)
 	local FILOption = GUIObj:addCheckBox("FloorIsLavaOpt", scrollPane, {"gui-description.FloorIsLavaOpt"}, {"gui-description.FloorIsLavaOptTT"}, global.floorIsLavaActivated or false)
 	FILOption.enabled = GUIObj.MFPlayer.ent.admin
+
+		-- Create the Category List --
+	local categoryList = {}
+	for _, recipe in pairs(game.recipe_prototypes) do
+		categoryList[recipe.category] = recipe.category
+	end
+
+	-- Add all Options --
+	GUI.addOption("", scrollPane, "title", false, {text={"gui-description.DataNetwork"}}, playerIndex)
+	GUIObj:addLabel("", scrollPane, {"gui-description.DABlacklistLabel"}, nil, {"gui-description.DABlacklistLabelTT"}, false, "LabelFont2")
+	local blacklistFlow = GUIObj:addFlow("", scrollPane, "horizontal")
+	GUIObj:addDropDown("blacklistDAList", blacklistFlow, categoryList, nil, true)
+	local add = GUIObj:addSimpleButton("blacklistDAAdd", blacklistFlow, {"gui-description.MFOptAddButton"})
+	local rem = GUIObj:addSimpleButton("blacklistDARem", blacklistFlow, {"gui-description.MFOptRemoveButton"})
+	add.enabled = GUIObj.MFPlayer.ent.admin
+	rem.enabled = GUIObj.MFPlayer.ent.admin
+
+	-- Add the Blacklisted Categories list --
+	for category, _ in pairs(global.dataAssemblerBlacklist) do
+		GUIObj:addLabel("", scrollPane, category, _mfRed)
+	end
 end
 
 -- Update the SystemTab --
@@ -179,5 +200,6 @@ function GUI.updateOptionGUISystemTab(GUIObj)
 	local tickOpt = GUI.addOption("UpdatePerTickOpt", scrollPane, "numberfield", false, {text=global.entsUpPerTick or 100, text2={"gui-description.SystemPerfEntsPerTick"}, tooltip={"gui-description.SystemPerfEntsPerTickTT"}}, playerIndex)
 	tickOpt.UpdatePerTickOpt.enabled = GUIObj.MFPlayer.ent.admin
 
-	GUIObj:addCheckBox("useVanillaChooseElem", scrollPane, {"gui-description.UseVanillaChooseElem"}, {"gui-description.UseVanillaChooseElemTT"}, global.useVanillaChooseElem)
+	local checkbox = GUIObj:addCheckBox("useVanillaChooseElem", scrollPane, {"gui-description.UseVanillaChooseElem"}, {"gui-description.UseVanillaChooseElemTT"}, global.useVanillaChooseElem)
+	checkbox.enabled = GUIObj.MFPlayer.ent.admin
 end

--- a/scripts/GUI/options.lua
+++ b/scripts/GUI/options.lua
@@ -75,7 +75,18 @@ function GUI.readOptions(option, player)
 			game.print({"gui-description.FloorIsLavaDeactivated"})
 		end
 	end
-	
+
+	if name == "blacklistDAAdd" then
+		local selectedCategory = GUIObj.blacklistDAList.items[GUIObj.blacklistDAList.selected_index]
+		if selectedCategory == nil then return end
+		global.dataAssemblerBlacklist[selectedCategory] = true
+	end
+	if name == "blacklistDARem" then
+		local selectedCategory = GUIObj.blacklistDAList.items[GUIObj.blacklistDAList.selected_index]
+		if selectedCategory == nil then return end
+		global.dataAssemblerBlacklist[selectedCategory] = nil
+	end
+
 	------------------- Performances -------------------
 	if name == "UpdatePerTickOpt" then
 		local number = tonumber(option.text)

--- a/scripts/GUI/recipe-gui.lua
+++ b/scripts/GUI/recipe-gui.lua
@@ -27,7 +27,7 @@ function GUI.createRecipeGUI(player)
 	-- Split recipes by groups
 	local recipeTable = {}
 	for _, r in pairs(player.force.recipes) do
-		if r.enabled == true and r.hidden == false then
+		if r.enabled == true and r.hidden == false and not global.dataAssemblerBlacklist[r.category] then
 			if recipeTable[r.group.name] == nil then
 				recipeTable[r.group.name] = {}
 			end

--- a/scripts/objects/data-assembler.lua
+++ b/scripts/objects/data-assembler.lua
@@ -331,7 +331,7 @@ function DA:addRecipe(name, amount)
 	local recipePrototype = game.recipe_prototypes[name]
 	if recipePrototype == nil then return end
 
-	if self.ent.force.recipes[name] == nil or not self.ent.force.recipes[name].enabled then
+	if self.ent.force.recipes[name] == nil or not self.ent.force.recipes[name].enabled or global.dataAssemblerBlacklist[recipePrototype.category] then
 		local player = getPlayer(self.player)
 		player.print({"", {"gui-description.DAWrongRecipe"}})
 		return

--- a/utils/remote.lua
+++ b/utils/remote.lua
@@ -69,6 +69,17 @@ function takeItems(name, item, amount)
     return 0
 end
 
+-- Add or remove crafting category to Data Assembler blacklist
+function blacklistDACategory(category, value)
+	if global.dataAssemblerBlacklist ~= nil then
+		if value then
+			global.dataAssemblerBlacklist[category] = true
+		else
+			global.dataAssemblerBlacklist[category] = nil
+		end
+	end
+end
+
 -- Add the MFCom Interface --
 remote.add_interface("MFCom", {
     getGlobal=getGlobal,
@@ -80,5 +91,6 @@ remote.add_interface("MFCom", {
     removeMFEnergy=removeMFEnergy,
     hasItems=hasItems,
     addItems=addItems,
-    takeItems=takeItems
+    takeItems=takeItems,
+    blacklistDACategory=blacklistDACategory
 })


### PR DESCRIPTION
That's the main reason why i started to work on recipe GUI, though legacy selector also works. 
Many mods adds recipes which can break balance\logic if crafted in DA. Some cheasy recipes supposed to be crafted in big expensive dirty machines, something that creates nothing but negative polution, something that generates items ouf of nothing, something that not supposed to be automated at all(handcraft only), an so on.
Now all those things can be banned from DA, either by mod authors via remote, or by player(admin).
Category names might not always be verbose and intuitive, but both admin and mod authors supposed to know what they're doing. That seems to be better that showing names\icons if crafting machines, as some machines have more than one category, some categories doesn't have machines, and that would make configurating even more complicated.
Requires increasing version number as new global var was added.