### PR TITLE
Desync fixes

### DIFF
--- a/migrations/0.0.a197to0.0.198.lua
+++ b/migrations/0.0.a197to0.0.198.lua
@@ -1,0 +1,15 @@
+for id, obj in pairs(global.deepStorageTable or {}) do
+	obj.entID = id
+end
+for id, obj in pairs(global.deepTankTable or {}) do
+	obj.entID = id
+end
+for id, obj in pairs(global.fluidExtractorTable or {}) do
+	obj.entID = id
+end
+for id, obj in pairs(global.networkAccessPointTable or {}) do
+	obj.entID = id
+end
+for id, obj in pairs(global.oreCleanerTable or {}) do
+	obj.entID = id
+end

--- a/scripts/objects/data-assembler.lua
+++ b/scripts/objects/data-assembler.lua
@@ -6,7 +6,7 @@ DA = {
 	player = "",
 	MF = nil,
 	entID = 0,
-    stateSprite = 0,
+	stateSprite = 0,
 	active = false,
 	consumption = _mfDAQuatronDrainPerUpdate,
 	updateTick = 5,
@@ -33,12 +33,12 @@ function DA:new(object)
 	if object.last_user == nil then return end
 	t.player = object.last_user.name
 	t.MF = getMF(t.player)
-	t.dataNetwork = t.MF.dataNetwork
 	t.entID = object.unit_number
+	t.dataNetwork = t.MF.dataNetwork
 	t.recipeTable = {}
-    UpSys.addObj(t)
-    -- Draw the state Sprite --
+	-- Draw the state Sprite --
 	t.stateSprite = rendering.draw_sprite{sprite="DataAssemblerSprite1", target=object, surface=object.surface, render_layer=131}
+	UpSys.addObj(t)
 	return t
 end
 

--- a/scripts/objects/data-storage.lua
+++ b/scripts/objects/data-storage.lua
@@ -13,21 +13,21 @@ DS = {
 }
 
 -- Constructor --
-function DS:new(ent)
-	if ent == nil then return end
+function DS:new(object)
+	if object == nil then return end
 	local t = {}
 	local mt = {}
 	setmetatable(t, mt)
 	mt.__index = DS
-	t.ent = ent
-	if ent.last_user == nil then return end
-	t.player = ent.last_user.name
+	t.ent = object
+	if object.last_user == nil then return end
+	t.player = object.last_user.name
 	t.MF = getMF(t.player)
+	t.entID = object.unit_number
 	t.dataNetwork = t.MF.dataNetwork
-	t.dataNetwork.dataStorageTable[ent.unit_number] = t
-	t.entID = ent.unit_number
+	t.dataNetwork.dataStorageTable[object.unit_number] = t
+	t.animID = rendering.draw_animation{animation="DataStorageA", target={object.position.x, object.position.y-1.2}, surface=object.surface, render_layer=131}
 	UpSys.addObj(t)
-	t.animID = rendering.draw_animation{animation="DataStorageA", target={ent.position.x,ent.position.y-1.2}, surface=ent.surface, render_layer=131}
 	return t
 end
 

--- a/scripts/objects/deep-storage.lua
+++ b/scripts/objects/deep-storage.lua
@@ -5,6 +5,7 @@ DSR = {
 	ent = nil,
 	player = "",
 	MF = nil,
+	entID = 0,
 	updateTick = 80,
 	lastUpdate = 0,
 	inventoryItem = nil,
@@ -24,6 +25,7 @@ function DSR:new(object)
 	if object.last_user == nil then return end
 	t.player = object.last_user.name
 	t.MF = getMF(t.player)
+	t.entID = object.unit_number
 	t.ID = Util.getEntID(global.deepStorageTable)
 	t.MF.dataNetwork.DSRTable[object.unit_number] = t
 	UpSys.addObj(t)

--- a/scripts/objects/deep-tank.lua
+++ b/scripts/objects/deep-tank.lua
@@ -5,6 +5,7 @@ DTK = {
 	ent = nil,
 	player = "",
 	MF = nil,
+	entID = 0,
 	updateTick = 80,
 	lastUpdate = 0,
 	inventoryFluid = nil,
@@ -25,6 +26,7 @@ function DTK:new(object)
 	if object.last_user == nil then return end
 	t.player = object.last_user.name
 	t.MF = getMF(t.player)
+	t.entID = object.unit_number
 	t.ID = Util.getEntID(global.deepTankTable)
 	if t.MF and t.MF.dataNetwork then
 		t.MF.dataNetwork.DTKTable[object.unit_number] = t

--- a/scripts/objects/energy-laser.lua
+++ b/scripts/objects/energy-laser.lua
@@ -28,9 +28,9 @@ function EL:new(object)
 	t.player = object.last_user.name
 	t.MF = getMF(t.player)
 	t.entID = object.unit_number
-	UpSys.addObj(t)
 	-- Create the Beam --
-	t.beam = t.ent.surface.create_entity{name="IddleBeam", position= EL.getBeamPositionA(t), target_position=EL.getBeamPositionB(t), source=EL.getBeamPositionA(t)}
+	t.beam = object.surface.create_entity{name="IddleBeam", position= EL.getBeamPositionA(t), target_position=EL.getBeamPositionB(t), source=EL.getBeamPositionA(t)}
+	UpSys.addObj(t)
 	return t
 end
 

--- a/scripts/objects/fluid-extractor.lua
+++ b/scripts/objects/fluid-extractor.lua
@@ -127,7 +127,7 @@ function FE:getTooltipInfos(GUIObj, gui, justCreated)
 					itemText = {"", " (", game.fluid_prototypes[deepTank.inventoryFluid].localised_name, ")"}
 				end
 				invs[k+1] = {"", {"gui-description.DT"}, " ", tostring(deepTank.ID), itemText}
-				if self.selectedInv == deepTank then
+				if self.selectedInv and self.selectedInv.entID == deepTank.entID then
 					selectedIndex = i
 				end
 			end

--- a/scripts/objects/fluid-extractor.lua
+++ b/scripts/objects/fluid-extractor.lua
@@ -4,6 +4,7 @@ FE = {
 	ent = nil,
 	player = "",
 	MF = nil,
+	entID = 0,
 	purity = 0,
 	charge = 0,
 	totalCharge = 0,
@@ -25,6 +26,7 @@ function FE:new(object)
 	if object.last_user == nil then return end
 	t.player = object.last_user.name
 	t.MF = getMF(t.player)
+	t.entID = object.unit_number
 	resource = object.surface.find_entities_filtered{position=object.position, radius=1, type="resource", limit=1}[1]
 	UpSys.addObj(t)
 	return t

--- a/scripts/objects/fluid-interactor.lua
+++ b/scripts/objects/fluid-interactor.lua
@@ -167,7 +167,7 @@ function FI:getTooltipInfos(GUIObj, gui, justCreated)
 				invs[k+1] = {"", "", {"gui-description.Empty"}, "", " - ", deepTank.ID}
 			end
 
-			if self.selectedInv == deepTank then
+			if self.selectedInv and type(self.selectedInv) == "table" and self.selectedInv.entID == deepTank.entID then
 				selectedIndex = i
 			end
 		end

--- a/scripts/objects/fluid-interactor.lua
+++ b/scripts/objects/fluid-interactor.lua
@@ -6,16 +6,16 @@ FI = {
 	player = "",
 	MF = nil,
 	entID = 0,
-    stateSprite = 0,
-    levelSprite = 0,
+	stateSprite = 0,
+	levelSprite = 0,
 	active = false,
 	consumption = _mfFIQuatronDrainPerUpdate,
 	updateTick = 60,
 	lastUpdate = 0,
 	dataNetwork = nil,
 	networkAccessPoint = nil,
-    selectedInv = 0,
-    selectedMode = "input" -- input or output
+	selectedInv = 0,
+	selectedMode = "input" -- input or output
 }
 
 -- Constructor --
@@ -29,11 +29,11 @@ function FI:new(object)
 	if object.last_user == nil then return end
 	t.player = object.last_user.name
 	t.MF = getMF(t.player)
-	t.dataNetwork = t.MF.dataNetwork
 	t.entID = object.unit_number
-    UpSys.addObj(t)
-    -- Draw the state Sprite --
+	t.dataNetwork = t.MF.dataNetwork
+	-- Draw the state Sprite --
 	t.stateSprite = rendering.draw_sprite{sprite="FluidInteractorSprite1", target=object, surface=object.surface, render_layer=131}
+	UpSys.addObj(t)
 	return t
 end
 

--- a/scripts/objects/jump-charger.lua
+++ b/scripts/objects/jump-charger.lua
@@ -2,30 +2,32 @@
 
 -- Create the Jump Charger base Object --
 JC = {
-    ent = nil,
-    entID = 0,
+	ent = nil,
 	player = "",
 	MF = nil,
-    lightID = 0,
+	entID = 0,
+	lightID = 0,
 	updateTick = 240,
 	lastUpdate = 0
 }
 
 -- Constructor --
-function JC:new(ent)
+function JC:new(object)
+	if object == nil then return end
 	local t = {}
 	local mt = {}
 	setmetatable(t, mt)
-    mt.__index = JC
-    t.ent = ent
-    t.entID = ent.unit_number
-    t.player = ent.last_user.name
-    t.MF = getMF(t.player)
-    -- Draw the Light Sprite --
-    t.lightID = rendering.draw_light{sprite="JumpChargerL", target=t.ent, surface=t.ent.surface, minimum_darkness=0}
-    -- Save the Jump Charger inside the Jump Drive Table --
-    t.MF.jumpDriveObj.jumpChargerTable[ent.unit_number] = t
-    UpSys.addObj(t)
+	mt.__index = JC
+	t.ent = object
+	if object.last_user == nil then return end
+	t.player = object.last_user.name
+	t.MF = getMF(t.player)
+	t.entID = object.unit_number
+	-- Draw the Light Sprite --
+	t.lightID = rendering.draw_light{sprite="JumpChargerL", target=object, surface=object.surface, minimum_darkness=0}
+	-- Save the Jump Charger inside the Jump Drive Table --
+	t.MF.jumpDriveObj.jumpChargerTable[object.unit_number] = t
+	UpSys.addObj(t)
 	return t
 end
 

--- a/scripts/objects/matter-interactor.lua
+++ b/scripts/objects/matter-interactor.lua
@@ -6,18 +6,18 @@ MI = {
 	player = "",
 	MF = nil,
 	entID = 0,
-    stateSprite = 0,
+	stateSprite = 0,
 	active = false,
 	consumption = _mfMIQuatronDrainPerUpdate,
 	updateTick = 60,
 	lastUpdate = 0,
-    dataNetwork = nil,
+	dataNetwork = nil,
 	networkAccessPoint = nil,
-    selectedFilter = nil,
-    selectedMode = "input", -- input or output
+	selectedFilter = nil,
+	selectedMode = "input", -- input or output
 	lastSelectedPlayer = "",
 	selectedPlayer = "",
-    selectedInv = 0,
+	selectedInv = 0,
 }
 
 -- Constructor --
@@ -32,11 +32,11 @@ function MI:new(object)
 	t.player = object.last_user.name
 	t.selectedPlayer = t.player
 	t.MF = getMF(t.player)
-	t.dataNetwork = t.MF.dataNetwork
 	t.entID = object.unit_number
-    UpSys.addObj(t)
-    -- Draw the state Sprite --
+	t.dataNetwork = t.MF.dataNetwork
+	-- Draw the state Sprite --
 	t.stateSprite = rendering.draw_sprite{sprite="MatterInteractorSprite1", target=object, surface=object.surface, render_layer=131}
+	UpSys.addObj(t)
 	return t
 end
 

--- a/scripts/objects/matter-interactor.lua
+++ b/scripts/objects/matter-interactor.lua
@@ -178,7 +178,7 @@ function MI:getTooltipInfos(GUIObj, gui, justCreated)
 
 	-- Create the Inventory and Deep Storage List --
 	local selectedIndex = 1
-	if self.selectedInv == self.dataNetwork.invObj then selectedIndex = 2 end
+	if self.selectedInv and type(self.selectedInv) == "table" and not self.selectedInv.ID then selectedIndex = 2 end
 	local i = 2
 	for k, deepStorage in pairs(self.dataNetwork.DSRTable) do
 		if deepStorage ~= nil and deepStorage.ent ~= nil then
@@ -196,7 +196,7 @@ function MI:getTooltipInfos(GUIObj, gui, justCreated)
 				invs[k+2] = {"", "", {"gui-description.Empty"}, " - ", deepStorage.ID}
 			end
 
-			if self.selectedInv == deepStorage then
+			if self.selectedInv and type(self.selectedInv) == "table" and self.selectedInv.entID == deepStorage.entID then
 				selectedIndex = i
 			end
 		end

--- a/scripts/objects/mobile-factory.lua
+++ b/scripts/objects/mobile-factory.lua
@@ -168,7 +168,7 @@ function MF:getTooltipInfos(GUIObj, gui, justCreated)
 						itemText = {"", " (", game.fluid_prototypes[deepTank.inventoryFluid].localised_name, " - ", deepTank.player, ")"}
 					end
 					invs[k+1] = {"", {"gui-description.DT"}, " ", tostring(deepTank.ID), itemText}
-					if self.selectedInv == deepTank then
+					if self.selectedInv and self.selectedInv.entID == deepTank.entID then
 						selectedIndex = i
 					end
 				end

--- a/scripts/objects/network-access-point.lua
+++ b/scripts/objects/network-access-point.lua
@@ -4,40 +4,42 @@
 NAP = {
 	ent = nil,
 	player = "",
-    MF = nil,
-    dataNetwork = nil,
-    networkAccessPoint = nil,
-    consumption = _mfNAPQuatronDrainPerUpdate,
-    quatronCharge = 0,
-    maxQuatronCharge = _mfNAPQuatronCapacity,
-    totalConsumption = 0,
-    outOfQuatron = false,
-    showArea = false,
-    areaRenderID = 0,
-    animID = 0,
-    noQuatronSpriteID = 0,
-    objTable = nil,
+	MF = nil,
+	entID = 0,
+	dataNetwork = nil,
+	networkAccessPoint = nil,
+	consumption = _mfNAPQuatronDrainPerUpdate,
+	quatronCharge = 0,
+	maxQuatronCharge = _mfNAPQuatronCapacity,
+	totalConsumption = 0,
+	outOfQuatron = false,
+	showArea = false,
+	areaRenderID = 0,
+	animID = 0,
+	noQuatronSpriteID = 0,
+	objTable = nil,
 	updateTick = 60,
 	lastUpdate = 0
 }
 
 -- Constructor --
-function NAP:new(ent)
-	if ent == nil then return end
+function NAP:new(object)
+	if object == nil then return end
 	local t = {}
 	local mt = {}
 	setmetatable(t, mt)
 	mt.__index = NAP
-	t.ent = ent
-	if ent.last_user == nil then return end
-	t.player = ent.last_user.name
-    t.MF = getMF(t.player)
-    t.dataNetwork = t.MF.dataNetwork
-    t.dataNetwork.networkAccessPointTable[ent.unit_number] = t
-    t.networkAccessPoint = t
-    t.objTable = {}
-    UpSys.addObj(t)
-    t.animID = rendering.draw_animation{animation="NetworkAccessPointA", target={ent.position.x,ent.position.y-0.9}, surface=ent.surface, render_layer=131}
+	t.ent = object
+	if object.last_user == nil then return end
+	t.player = object.last_user.name
+	t.MF = getMF(t.player)
+	t.entID = object.unit_number
+	t.dataNetwork = t.MF.dataNetwork
+	t.dataNetwork.networkAccessPointTable[object.unit_number] = t
+	t.networkAccessPoint = t
+	t.objTable = {}
+	t.animID = rendering.draw_animation{animation="NetworkAccessPointA", target={object.position.x, object.position.y-0.9}, surface=object.surface, render_layer=131}
+	UpSys.addObj(t)
 	return t
 end
 

--- a/scripts/objects/network-explorer.lua
+++ b/scripts/objects/network-explorer.lua
@@ -6,7 +6,7 @@ NE = {
 	player = "",
 	MF = nil,
 	entID = 0,
-    stateSprite = 0,
+	stateSprite = 0,
 	active = false,
 	consumption = _mfNEQuatronDrainPerUpdate,
 	updateTick = 60,
@@ -26,11 +26,11 @@ function NE:new(object)
 	if object.last_user == nil then return end
 	t.player = object.last_user.name
 	t.MF = getMF(t.player)
-	t.dataNetwork = t.MF.dataNetwork
 	t.entID = object.unit_number
-    UpSys.addObj(t)
-    -- Draw the state Sprite --
+	t.dataNetwork = t.MF.dataNetwork
+	-- Draw the state Sprite --
 	t.stateSprite = rendering.draw_sprite{sprite="NetworkExplorerSprite1", target=object, surface=object.surface, render_layer=131}
+	UpSys.addObj(t)
 	return t
 end
 

--- a/scripts/objects/ore-cleaner.lua
+++ b/scripts/objects/ore-cleaner.lua
@@ -140,7 +140,7 @@ function OC:getTooltipInfos(GUIObj, gui, justCreated)
 					itemText = {"", " (", game.item_prototypes[deepStorage.inventoryItem].localised_name, ")"}
 				end
 				invs[k+1] = {"", {"gui-description.DS"}, " ", tostring(deepStorage.ID), itemText}
-				if self.selectedInv == deepStorage then
+				if self.selectedInv and self.selectedInv.entID == deepStorage.entID then
 					selectedIndex = i
 				end
 			end

--- a/scripts/objects/ore-cleaner.lua
+++ b/scripts/objects/ore-cleaner.lua
@@ -4,6 +4,7 @@ OC = {
 	ent = nil,
 	player = "",
 	MF = nil,
+	entID = 0,
 	purity = 0,
 	charge = 0,
 	totalCharge = 0,
@@ -28,10 +29,11 @@ function OC:new(object)
 	if object.last_user == nil then return end
 	t.player = object.last_user.name
 	t.MF = getMF(t.player)
+	t.entID = object.unit_number
 	t.oreTable = {}
 	t.inventory = {}
-	UpSys.addObj(t)
 	t:scanOres(object)
+	UpSys.addObj(t)
 	return t
 end
 

--- a/scripts/objects/quatron-laser.lua
+++ b/scripts/objects/quatron-laser.lua
@@ -28,9 +28,9 @@ function QL:new(object)
 	t.player = object.last_user.name
 	t.MF = getMF(t.player)
 	t.entID = object.unit_number
-	UpSys.addObj(t)
 	-- Create the Beam --
-	t.beam = t.ent.surface.create_entity{name="IddleBeam", position= QL.getBeamPositionA(t), target_position=QL.getBeamPositionB(t), source=QL.getBeamPositionA(t)}
+	t.beam = object.surface.create_entity{name="IddleBeam", position= QL.getBeamPositionA(t), target_position=QL.getBeamPositionB(t), source=QL.getBeamPositionA(t)}
+	UpSys.addObj(t)
 	return t
 end
 

--- a/scripts/objects/resource-catcher.lua
+++ b/scripts/objects/resource-catcher.lua
@@ -6,34 +6,36 @@ local waterTileList = {deepwater=true, ["deepwater-green"]=true, water=true, ["w
 
 -- Create the Resource Catcher base Object --
 RC = {
-    ent = nil,
-    entID = 0,
+	ent = nil,
 	player = "",
 	MF = nil,
-    lightID = 0,
-    spriteID = 0,
-    updateTick = 100,
-    justCreated = true,
-    filled = false,
-    haveResource = false,
-    resourceName = nil,
-    resourceAmount = nil,
+	entID = 0,
+	lightID = 0,
+	spriteID = 0,
+	updateTick = 100,
+	justCreated = true,
+	filled = false,
+	haveResource = false,
+	resourceName = nil,
+	resourceAmount = nil,
 	lastUpdate = 0
 }
 
 -- Constructor --
-function RC:new(ent)
+function RC:new(object)
+	if object == nil then return end
 	local t = {}
 	local mt = {}
 	setmetatable(t, mt)
-    mt.__index = RC
-    t.ent = ent
-    t.entID = ent.unit_number
-    t.player = ent.last_user.name
-    t.MF = getMF(t.player)
-    -- Draw the Light Sprite --
-    t.lightID = rendering.draw_light{sprite="ResourceCatcher", target=t.ent, surface=t.ent.surface, minimum_darkness=0}
-    UpSys.addObj(t)
+	mt.__index = RC
+	t.ent = object
+	if object.last_user == nil then return end
+	t.player = object.last_user.name
+	t.MF = getMF(t.player)
+	t.entID = object.unit_number
+	-- Draw the Light Sprite --
+	t.lightID = rendering.draw_light{sprite="ResourceCatcher", target=object, surface=object.surface, minimum_darkness=0}
+	UpSys.addObj(t)
 	return t
 end
 

--- a/scripts/update-system.lua
+++ b/scripts/update-system.lua
@@ -9,12 +9,10 @@ end
 
 -- Remove an Object from the Update System --
 function UpSys.removeObj(obj)
-  -- Remove the Object --
-  for k, object in pairs(global.entsTable) do
-    if object == obj then
-      global.entsTable[k] = nil
-    end
-  end
+	-- Remove the Object --
+	if obj.entID then
+		global.entsTable[obj.entID] = nil
+	end
 end
 
 -- Update System: Scan Entities --

--- a/utils/cc-extension.lua
+++ b/utils/cc-extension.lua
@@ -50,16 +50,20 @@ end
 function createNetworkControllerArea(MF)
 	createRightPassage(MF.ccS)
 	createTilesSurface(MF.ccS, 10, 3, 90, 10, "BuildTile")
-	local ent = createEntity(MF.ccS, 14, 6, "NetworkController", getMFPlayer(MF.playerIndex).ent.force, MF.playerIndex)
-	MF.networkController = NC:new(ent)
+	if MF.networkController == nil then
+		local ent = createEntity(MF.ccS, 14, 6, "NetworkController", getMFPlayer(MF.playerIndex).ent.force, MF.playerIndex)
+		MF.networkController = NC:new(ent)
+	end
 end
 
 -- Create the Jump Drive --
 function createJumpDriveArea(MF)
 	createTilesSurface(MF.ccS, -90, 3, -10, 10, "BuildTile")
-	local jd = createEntity(MF.ccS, -14, 6, "JumpDrive", getMFPlayer(MF.playerIndex).ent.force)
-	jd.last_user = MF.player
-	MF.jumpDriveObj.ent = jd
+	if MF.jumpDriveObj.ent == nil then
+		local jd = createEntity(MF.ccS, -14, 6, "JumpDrive", getMFPlayer(MF.playerIndex).ent.force)
+		jd.last_user = MF.player
+		MF.jumpDriveObj.ent = jd
+	end
 end
 
 -- Create Deep Storage Building Area --

--- a/utils/place-and-remove.lua
+++ b/utils/place-and-remove.lua
@@ -189,6 +189,7 @@ function somethingWasRemoved(event)
 			event.buffer.insert("FilledResourceCatcher")
 			obj:contentToItemTags(event.buffer[1])
 		end
+		obj:remove()
 		return
 	end
 


### PR DESCRIPTION
Fixed creating extra Jump Drives and Network Controllers, added missing entID to constructors, and migrated objects created with old constructors, and changed UpSys.removeObj() to compare IDs instead if tables.
Also refactored those constructors a bit by the way, in one style.