### PR TITLE
Fixed fuel issues

### DIFF
--- a/scripts/objects/mobile-factory.lua
+++ b/scripts/objects/mobile-factory.lua
@@ -493,16 +493,21 @@ function MF:updateFuel()
 	-- Check if the Mobile Factory is valid --
 	if self.ent == nil or self.ent.valid == false then return end
 	-- Recharge the tank fuel --
-	if self.internalEnergyObj:energy() > 0 and self.ent.get_inventory(defines.inventory.fuel).get_item_count() < 2 then
-		if self.ent.burner.remaining_burning_fuel == 0 and self.ent.get_inventory(defines.inventory.fuel).is_empty() == true then
+	if self.ent.get_inventory(defines.inventory.fuel).is_empty() then
+		local fuel = game.item_prototypes['coal']
+		if self.ent.burner.currently_burning == nil then
 			-- Insert coal in case of the Tank is off --
-			self.ent.get_inventory(defines.inventory.fuel).insert({name="coal", count=1})
-		elseif self.ent.burner.remaining_burning_fuel > 0 then
+			if self.internalEnergyObj:energy() >= fuel.fuel_value/_mfFuelMultiplicator then
+				self.ent.burner.currently_burning = fuel
+				self.internalEnergyObj:removeEnergy(fuel.fuel_value/_mfFuelMultiplicator)
+			end
+		elseif self.ent.burner.currently_burning == fuel then
 			-- Calcule the missing Fuel amount --
-			local missingFuelValue = math.floor((_mfMaxFuelValue - self.ent.burner.remaining_burning_fuel) /_mfFuelMultiplicator)
-			if math.floor(missingFuelValue/_mfFuelMultiplicator) < self.internalEnergyObj:energy() then
+			local remainingFuelValue = self.ent.burner.remaining_burning_fuel
+			local missingFuelValue = math.floor(fuel.fuel_value - remainingFuelValue)
+			if missingFuelValue > 0 and self.internalEnergyObj:energy() >= missingFuelValue/_mfFuelMultiplicator then
 				-- Add the missing Fuel to the Tank --
-				self.ent.burner.remaining_burning_fuel = _mfMaxFuelValue
+				self.ent.burner.remaining_burning_fuel = remainingFuelValue + missingFuelValue
 				-- Drain energy --
 				self.internalEnergyObj:removeEnergy(missingFuelValue/_mfFuelMultiplicator)
 			end


### PR DESCRIPTION
You can't dupe fuel anymore by taking created piece of coal(which doesn't even cost any energy), as fuel value now adds directly, without creating any items. That also solves fuel incompatibility, when some mods forbid using coal in tanks(base prototype for MF).