### PR TITLE
MF tooltip gui open self entity

### DIFF
--- a/scripts/objects/mobile-factory.lua
+++ b/scripts/objects/mobile-factory.lua
@@ -132,7 +132,7 @@ function MF:getTooltipInfos(GUIObj, gui, justCreated)
 		local inventoryTitle = GUIObj:addTitledFrame("", gui, "vertical", {"gui-description.Inventory"}, _mfOrange)
 
 		-- Create the Inventory Button --
-		GUIObj:addSimpleButton("MFOpenI," ..GUIObj.MFPlayer.name, inventoryTitle, {"gui-description.OpenInventory"})
+		GUIObj:addSimpleButton("MFOpenI," ..self.player, inventoryTitle, {"gui-description.OpenInventory"})
 
 		-- Create the Lasers Title --
 		local LasersFrame = GUIObj:addTitledFrame("", gui, "vertical", {"gui-description.Lasers"}, _mfOrange)


### PR DESCRIPTION
Alice adds Bob to allowed list. Bob opens Alice's MF Tooltip(by clicking on her mobile factory), tries to open inventory... and seeing trunk of his own mobile factory. (Or nothing at all, if his own factory entity is too far)
Now it fixed.