### PR TITLE
Validate prototypes

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -70,17 +70,23 @@ function onInit()
 
 	-- Create the Objects Table --
 	Util.createTableList()
-
-	-- Rebuild all Objects --
-	for k, obj in pairs(global.objTable) do
-		if obj.tableName and obj.tag and _G[obj.tag].refresh then
-			for objKey, entry in pairs(global[obj.tableName]) do
-				_G[obj.tag]:refresh(entry)
+	-- Migrate all Objects --
+	for _, obj in pairs(global.objTable) do
+		if obj.tableName and obj.tag then
+			if _G[obj.tag].refresh then
+				for _, entry in pairs(global[obj.tableName]) do
+					entry:refresh()
+				end
+			end
+			if _G[obj.tag].validate then
+				for _, entry in pairs(global[obj.tableName]) do
+					entry:validate()
+				end
 			end
 		end
 	end
 
-    global.syncTile = global.syncTile or "dirt-7"
+	global.syncTile = global.syncTile or "dirt-7"
 	-- Validate the Tile Used for the Sync Area --
 	validateSyncAreaTile()
 	-- Ensure All Needed Tiles are Present --
@@ -102,11 +108,9 @@ function onLoad(event)
 	
 	-- Rebuild all Objects --
 	for k, obj in pairs(global.objTable) do
-		if obj.tableName ~= nil and obj.tag ~= nil then
+		if obj.tableName ~= nil and obj.tag ~= nil and _G[obj.tag] ~= nil then
 			for objKey, entry in pairs(global[obj.tableName] or {}) do
-				if _G[obj.tag] ~= nil then
-					_G[obj.tag]:rebuild(entry)
-				end
+				_G[obj.tag]:rebuild(entry)
 			end
 		end
 	end

--- a/locale/en/config.cfg
+++ b/locale/en/config.cfg
@@ -571,6 +571,7 @@ FocusModuleUpgrade=Number of Focus Modules
 DeepTankID=Deep Tank ID
 DeepStorageID=Deep Storage ID
 DeepTankFluid=Fluid Stored
+DeepStorageItem=Items Stored
 Count=Count
 InventoryName=Inventory Name
 InventoryCapacity=Capacity

--- a/scripts/GUI/info-gui.lua
+++ b/scripts/GUI/info-gui.lua
@@ -78,7 +78,7 @@ end
 function GUI.updateMFInfoGUI(GUIObj)
 	GUI.updateButtonsBar(GUIObj)
 	GUI.updateMFInfos(GUIObj)
-	GUI.updateTankFrame(GUIObj)
+	GUI.updateDeepTankFrame(GUIObj)
 	GUI.updateDeepStorageFrame(GUIObj)
 	GUI.updateInventoryFrame(GUIObj)
 end
@@ -231,7 +231,7 @@ function GUI.updateMFInfos(GUIObj)
 end
 
 -- Update Tank Frame --
-function GUI.updateTankFrame(GUIObj)
+function GUI.updateDeepTankFrame(GUIObj)
 
 	-- Get the GUI, MF and Player--
 	local player = GUIObj.MFPlayer.ent
@@ -247,14 +247,11 @@ function GUI.updateTankFrame(GUIObj)
 
 		-- -- Create the Tank Variables --
 		local sprite = nil
-		local fName = Util.getLocFluidName(deepTank.inventoryFluid) or Util.getLocFluidName(deepTank.filter) or nil
-		local fAmount = deepTank.inventoryCount or 0
+		local fName = nil
+		local fAmount = 0
 		local tCapacity = _dtMaxFluid
-		local tankText = fName == nil and {"", {"gui-description.DeepTank"}, " ", deepTank.ID} or {"", {"gui-description.DeepTank"}, " ", deepTank.ID, ": ", fName, " ", Util.toRNumber(fAmount), "/", Util.toRNumber(tCapacity)}
+		local tankText = nil
 		local color = _mfPurple
-		if game.fluid_prototypes[deepTank.inventoryFluid] ~= nil then
-			color = game.fluid_prototypes[deepTank.inventoryFluid].base_color
-		end
 
 		-- Create the Frame --
 		local frame = GUIObj:addFrame("", tankScrollPane, "horizontal")
@@ -262,11 +259,17 @@ function GUI.updateTankFrame(GUIObj)
 		-- Create the Button --
 		if deepTank.inventoryFluid ~= nil then
 			sprite = "fluid/" .. deepTank.inventoryFluid
+			fName = Util.getLocFluidName(deepTank.inventoryFluid)
+			fAmount = deepTank.inventoryCount
+			tankText = {"", {"gui-description.DeepTank"}, " ", deepTank.ID, ": ", fName, " ", Util.toRNumber(fAmount), "/", Util.toRNumber(tCapacity)}
+			color = game.fluid_prototypes[deepTank.inventoryFluid].base_color
 		elseif deepTank.filter ~= nil then
 			sprite = "fluid/" .. deepTank.filter
+			fName = Util.getLocFluidName(deepTank.filter)
+			tankText = {"", {"gui-description.DeepTank"}, " ", deepTank.ID, ": ", fName, " ", Util.toRNumber(fAmount), "/", Util.toRNumber(tCapacity)}
 		else
 			sprite = "item/DeepTank"
-			fAmount = nil
+			tankText = {"", {"gui-description.DeepTank"}, " ", deepTank.ID}
 		end
 		local button = GUIObj:addButton("DTB" .. tostring(k), frame, sprite, sprite, tankText, 35, false, true, fAmount)
 		button.style = "MF_Purple_Button_Purple"
@@ -280,7 +283,7 @@ function GUI.updateTankFrame(GUIObj)
 		label.Label2.style.width = 70
 
 		-- Create the Progress Bar --
-		local bar = GUIObj:addProgressBar("", flow, "", "", false, color, (fAmount or 0)/tCapacity, 140)
+		local bar = GUIObj:addProgressBar("", flow, "", "", false, color, fAmount/tCapacity, 140)
 		bar.style.horizontally_stretchable = true
 		bar.style.top_padding = 7
 
@@ -303,15 +306,15 @@ function GUI.updateDeepTankInfo(GUIObj, id)
 	-- Create all Labels --
 	GUIObj:addDualLabel(gui, {"", {"gui-description.DeepTankID"}, ":"}, deepTank.ID, _mfOrange, _mfGreen)
 	GUIObj:addDualLabel(gui, {"", {"gui-description.BelongsTo"}, ":"}, deepTank.player, _mfOrange, _mfGreen)
-	GUIObj:addDualLabel(gui, {"", {"gui-description.DeepTankFluid"}, ":"}, Util.getLocFluidName(deepTank.inventoryFluid) or {"gui-description.None"}, _mfOrange, _mfGreen)
+	GUIObj:addDualLabel(gui, {"", {"gui-description.DeepTankFluid"}, ":"}, deepTank.inventoryFluid ~= nil and Util.getLocFluidName(deepTank.inventoryFluid) or {"gui-description.None"}, _mfOrange, _mfGreen)
 	GUIObj:addDualLabel(gui, {"", {"gui-description.Count"}, ":"}, (deepTank.inventoryCount or "0") .. "/" .. _dtMaxFluid, _mfOrange, _mfGreen)
-	GUIObj:addDualLabel(gui, {"", {"gui-description.Filter"}, ":"}, Util.getLocFluidName(deepTank.filter) or {"gui-description.None"}, _mfOrange, _mfGreen)
+	GUIObj:addDualLabel(gui, {"", {"gui-description.Filter"}, ":"}, deepTank.filter ~= nil and Util.getLocFluidName(deepTank.filter) or {"gui-description.None"}, _mfOrange, _mfGreen)
 
 	-- Create the Filter --
 	local TankFilter = GUIObj:addFilter("TF" .. tostring(id), gui, {"gui-description.FilterSelect"}, true, "fluid", 25)
 
 	-- Set the Filter --
-	if game.fluid_prototypes[deepTank.filter] ~= nil  then
+	if deepTank.filter ~= nil  then
 		TankFilter.elem_value = deepTank.filter
 	end
 
@@ -334,22 +337,30 @@ function GUI.updateDeepStorageFrame(GUIObj)
 
 		-- Create the Storage Variables --
 		local sprite = nil
-		local fName = Util.getLocItemName(deepStorage.inventoryItem) or Util.getLocItemName(deepStorage.filter) or nil
-		local fAmount = deepStorage.inventoryCount or 0
-		local storageText = fName == nil and {"", {"gui-description.DeepStorage"}, " ", deepStorage.ID} or {"", {"gui-description.DeepStorage"}, " ", deepStorage.ID, ": ", fName, " ", Util.toRNumber(fAmount)}
-				
+		local fName = nil
+		local fAmount = nil
+		local storageText = nil
+
 		-- Create the Frame --
 		local frame = GUIObj:addFrame("", storageScrollPane, "horizontal")
 
 		-- Create the Button --
 		if deepStorage.inventoryItem ~= nil then
 			sprite = "item/" .. deepStorage.inventoryItem
+			fName = Util.getLocItemName(deepStorage.inventoryItem)
+			fAmount = deepStorage.inventoryCount
+			storageText = {"", {"gui-description.DeepStorage"}, " ", deepStorage.ID, ": ", fName, " ", Util.toRNumber(fAmount)}
 		elseif deepStorage.filter ~= nil then
 			sprite = "item/" .. deepStorage.filter
+			fName = Util.getLocItemName(deepStorage.filter)
+			fAmount = 0
+			storageText = {"", {"gui-description.DeepStorage"}, " ", deepStorage.ID, ": ", fName, " ", Util.toRNumber(fAmount)}
 		else
 			sprite = "item/DeepStorage"
-			fAmount = nil
+			storageText = {"", {"gui-description.DeepStorage"}, " ", deepStorage.ID}
+			fAmount = ""
 		end
+
 		local button = GUIObj:addButton("DSRB" .. tostring(k), frame, sprite, sprite, storageText, 35, false, true, fAmount)
 		button.style = "shortcut_bar_button_green"
 
@@ -358,7 +369,7 @@ function GUI.updateDeepStorageFrame(GUIObj)
 
 		-- Create the Label --
 		local label1 = GUIObj:addLabel("", flow, fName or storageText, _mfOrange)
-		local label2 = GUIObj:addLabel("", flow, fAmount == nil and "" or fAmount, _mfGreen)
+		local label2 = GUIObj:addLabel("", flow, fAmount, _mfGreen)
 		label1.style.width = 70
 		label1.style.height = 15
 		label2.style.width = 70
@@ -383,15 +394,15 @@ function GUI.updateDeepStorageInfo(GUIObj, id)
 	-- Create all Labels --
 	GUIObj:addDualLabel(gui, {"", {"gui-description.DeepStorageID"}, ":"}, deepStorage.ID, _mfOrange, _mfGreen)
 	GUIObj:addDualLabel(gui, {"", {"gui-description.BelongsTo"}, ":"}, deepStorage.player, _mfOrange, _mfGreen)
-	GUIObj:addDualLabel(gui, {"", {"gui-description.DeepTankFluid"}, ":"}, Util.getLocFluidName(deepStorage.inventoryItem) or {"gui-description.None"}, _mfOrange, _mfGreen)
+	GUIObj:addDualLabel(gui, {"", {"gui-description.DeepStorageItem"}, ":"}, deepStorage.inventoryItem ~= nil and Util.getLocItemName(deepStorage.inventoryItem) or {"gui-description.None"}, _mfOrange, _mfGreen)
 	GUIObj:addDualLabel(gui, {"", {"gui-description.Count"}, ":"}, (deepStorage.inventoryCount or "0"), _mfOrange, _mfGreen)
-	GUIObj:addDualLabel(gui, {"", {"gui-description.Filter"}, ":"}, Util.getLocItemName(deepStorage.filter) or {"gui-description.None"}, _mfOrange, _mfGreen)
+	GUIObj:addDualLabel(gui, {"", {"gui-description.Filter"}, ":"}, deepStorage.filter ~= nil and Util.getLocItemName(deepStorage.filter) or {"gui-description.None"}, _mfOrange, _mfGreen)
 
 	-- Create the Filter --
 	local StorageFilter = GUIObj:addFilter("DSRF" .. tostring(id), gui, {"gui-description.FilterSelect"}, true, "item", 25)
 
 	-- Save the Filter --
-	if game.item_prototypes[deepStorage.filter] ~= nil  then
+	if deepStorage.filter ~= nil  then
 		StorageFilter.elem_value = deepStorage.filter
 	end
 
@@ -444,20 +455,20 @@ function GUI.updateInventoryInfo(GUIObj, id, type, name, amount)
 
 	if type == "DT" then
 		local deepTank = global.deepTankTable[id]
-		if game.fluid_prototypes[deepTank.inventoryFluid] == nil then return end
+		if deepTank.inventoryFluid == nil then return end
 		text = {"", {"gui-description.Fluid"}, ": "}
 		text2 = Util.getLocFluidName(deepTank.inventoryFluid)
 		count = deepTank.inventoryCount
 		location = {"", {"gui-description.DeepTank"}, " ", deepTank.ID}
 	elseif type == "DSR" then
 		local deepStorage = global.deepStorageTable[id]
-		if game.item_prototypes[deepStorage.inventoryItem] == nil then return end
+		if deepStorage.inventoryItem == nil then return end
 		text = {"", {"gui-description.Item"}, ": "}
 		text2 = Util.getLocItemName(deepStorage.inventoryItem)
 		count = deepStorage.inventoryCount
 		location = {"", {"gui-description.DeepStorage"}, " ", deepStorage.ID}
 	elseif type == "INV" then
-		if game.item_prototypes[name] == nil then return end
+		if name == nil then return end
 		text = {"", {"gui-description.Item"}, ": "}
 		text2 = Util.getLocItemName(name)
 		count = amount

--- a/scripts/GUI/tp-gui.lua
+++ b/scripts/GUI/tp-gui.lua
@@ -131,7 +131,7 @@ function GUI.updateLocation(GUIObj)
         local infoFlow = GUIObj:addFlow("", frame, "horizontal")
 
         -- Add the TP Button --
-        local icon = (loc.filter ~= nil and game.recipe_prototypes[loc.filter] ~= nil) and ("recipe/" .. loc.filter) or "MFJDIcon"
+        local icon = loc.filter ~= nil and ("recipe/" .. loc.filter) or "MFJDIcon"
         local button = GUIObj:addButton("TPGUILoc," .. name, infoFlow, icon, icon, {"gui-description.StartJump"}, 40)
         button.style = canTP == true and "shortcut_bar_button_green" or "MF_Fake_Button_Red"
         button.style.padding = 0

--- a/scripts/objects/data-network.lua
+++ b/scripts/objects/data-network.lua
@@ -146,8 +146,6 @@ end
 
 -- Get Items from the Data Network --
 function DN:getItem(item, amount)
-	-- Check if the Item still exist --
-	if game.item_prototypes[item] == nil then return 0 end
 	-- Set the Amount of Item to retrieve left --
 	local amountLeft = amount
 	-- Check the Deep Storages --
@@ -164,8 +162,6 @@ end
 
 -- Get Fluid form the Data Network --
 function DN:getFluid(fluid, amount)
-	-- Check if the Fluid still exist --
-	if game.fluid_prototypes[fluid] == nil then return 0 end
 	-- Set the Amount of Item to retrieve left --
 	local amountLeft = amount
 	-- Check the Deep Tanks --
@@ -204,8 +200,6 @@ end
 
 -- Send Items to the Data Network --
 function DN:addItems(item, amount)
-	-- Check if the Item still exist --
-	if game.item_prototypes[item] == nil then return 0 end
 	-- Set the Amount of Item to send left --
 	local amountLeft = amount
 	-- Check the Deep Storages --
@@ -223,8 +217,6 @@ end
 
 -- Send Fluid to the Data Network --
 function DN:addFluid(fluid, amount, temperature)
-	-- Check if the Fluid still exist --
-	if game.fluid_prototypes[fluid] == nil then return 0 end
 	-- Set the Amount of Item to retrieve left --
 	local amountLeft = amount
 	-- Check the Deep Tanks --

--- a/scripts/objects/deep-storage.lua
+++ b/scripts/objects/deep-storage.lua
@@ -84,20 +84,7 @@ function DSR:update()
 		self:remove()
 		return
 	end
-	
-	-- Remove the Item if it doesn't exist anymore --
-	if self.inventoryItem ~= nil and game.item_prototypes[self.inventoryItem] == nil then
-		self.inventoryItem = nil
-		self.inventoryCount = 0
-		return
-	end
 
-	-- Remove the Item Filter if it doesn't exist anymore --
-	if self.filter ~= nil and game.item_prototypes[self.filter] == nil then
-		self.filter = nil
-		return
-	end
-	
 	-- Display the Item Icon --
 	if self.inventoryItem == nil and self.filter == nil then return true end
 	local sprite = "item/" .. (self.inventoryItem or self.filter)
@@ -134,7 +121,15 @@ function DSR:getTooltipInfos(GUIObj, gui, justCreated)
 	end
 
 	-- Create the Item Name Label --
-	local itemName = Util.getLocItemName(self.inventoryItem) or Util.getLocItemName(self.filter) or {"gui-description.Empty"}
+	local itemName = nil
+	if self.inventoryItem ~= nil then
+		itemName = Util.getLocItemName(self.inventoryItem)
+	elseif self.filter ~= nil then
+		itemName = Util.getLocItemName(self.filter)
+	else
+		itemName = {"gui-description.Empty"}
+	end
+
 	GUIObj:addDualLabel(inventoryFlow, {"", {"gui-description.ItemName"}, ":"}, itemName, _mfOrange, _mfGreen)
 
 	-- Create the Item Amount Label --
@@ -142,11 +137,11 @@ function DSR:getTooltipInfos(GUIObj, gui, justCreated)
 	GUIObj:addDualLabel(inventoryFlow, {"", {"gui-description.Amount"}, ":"}, Util.toRNumber(itemAmount), _mfOrange, _mfGreen, nil, nil, itemAmount)
 
 	-- Create the Filter Label --
-	local filterName = Util.getLocItemName(self.filter) or {"gui-description.None"}
+	local filterName = self.filter ~= nil and Util.getLocItemName(self.filter) or {"gui-description.None"}
 	GUIObj:addDualLabel(inventoryFlow, {"", {"gui-description.Filter"}, ":"}, filterName, _mfOrange, _mfGreen)
 
 	-- Update the Filter --
-	if game.item_prototypes[self.filter] ~= nil and GUIObj["DSRF" .. tostring(self.ent.unit_number)] ~= nil then
+	if self.filter ~= nil and GUIObj["DSRF" .. tostring(self.ent.unit_number)] ~= nil then
 		GUIObj["DSRF" .. tostring(self.ent.unit_number)].elem_value = self.filter
 	end
 
@@ -199,4 +194,18 @@ end
 -- Blueprint Tags To Settings --
 function DSR:blueprintTagsToSettings(tags)
 	self.filter = tags["selfFilter"]
+end
+
+-- Check stored data, and remove invalid record
+function DSR:validate()
+	-- Remove the Item if it doesn't exist anymore --
+	if self.inventoryItem ~= nil and game.item_prototypes[self.inventoryItem] == nil then
+		self.inventoryItem = nil
+		self.inventoryCount = 0
+	end
+
+	-- Remove the Item Filter if it doesn't exist anymore --
+	if self.filter ~= nil and game.item_prototypes[self.filter] == nil then
+		self.filter = nil
+	end
 end

--- a/scripts/objects/deep-tank.lua
+++ b/scripts/objects/deep-tank.lua
@@ -89,20 +89,6 @@ function DTK:update()
 		return
 	end
 	
-	-- Remove the Fluid if it doesn't exist anymore --
-	if self.inventoryFluid ~= nil and game.fluid_prototypes[self.inventoryFluid] == nil then
-		self.inventoryFluid = nil
-		self.inventoryCount = 0
-		self.inventoryTemperature = 0
-		return
-	end
-
-	-- Remove the Fluid Filter if it doesn't exist anymore --
-	if self.filter ~= nil and game.fluid_prototypes[self.filter] == nil then
-		self.filter = nil
-		return
-	end
-	
 	-- Display the Item Icon --
 	if self.inventoryFluid == nil and self.filter == nil then return end
 	local sprite = "fluid/" .. (self.inventoryFluid or self.filter)
@@ -139,7 +125,15 @@ function DTK:getTooltipInfos(GUIObj, gui, justCreated)
 	end
 
 	-- Create the Fluid Name Label --
-	local fluidName = Util.getLocFluidName(self.inventoryFluid) or Util.getLocFluidName(self.filter) or {"gui-description.Empty"}
+	local fluidName = nil
+	if self.inventoryFluid ~= nil then
+		fluidName = Util.getLocFluidName(self.inventoryFluid)
+	elseif self.filter ~= nil then
+		fluidName = Util.getLocFluidName(self.filter)
+	else
+		fluidName = {"gui-description.Empty"}
+	end
+
 	GUIObj:addDualLabel(inventoryFlow, {"", {"gui-description.FluidName"}, ":"}, fluidName, _mfOrange, _mfGreen)
 
 	-- Create the Fluid Amount Label --
@@ -147,11 +141,11 @@ function DTK:getTooltipInfos(GUIObj, gui, justCreated)
 	GUIObj:addDualLabel(inventoryFlow, {"", {"gui-description.Amount"}, ":"}, Util.toRNumber(fluidAmount) .. "/" .. Util.toRNumber(_dtMaxFluid), _mfOrange, _mfGreen, nil, nil, fluidAmount .. "/" .. _dtMaxFluid)
 
 	-- Create the Filter Label --
-	local filterName = Util.getLocFluidName(self.filter) or {"gui-description.None"}
+	local filterName = self.filter ~= nil and Util.getLocFluidName(self.filter) or {"gui-description.None"}
 	GUIObj:addDualLabel(inventoryFlow, {"", {"gui-description.Filter"}, ":"}, filterName, _mfOrange, _mfGreen)
 
 	-- Update the Filter --
-	if game.fluid_prototypes[self.filter] ~= nil and GUIObj["TF" .. tostring(self.ent.unit_number)] ~= nil then
+	if self.filter ~= nil and GUIObj["TF" .. tostring(self.ent.unit_number)] ~= nil then
 		GUIObj["TF" .. tostring(self.ent.unit_number)].elem_value = self.filter
 	end
 
@@ -210,4 +204,21 @@ end
 -- Blueprint Tags To Settings --
 function DTK:blueprintTagsToSettings(tags)
 	self.filter = tags["selfFilter"]
+end
+
+-- Check stored data, and remove invalid record
+function DTK:validate()
+	-- Remove the Fluid if it doesn't exist anymore --
+	if self.inventoryFluid ~= nil and game.fluid_prototypes[self.inventoryFluid] == nil then
+		self.inventoryFluid = nil
+		self.inventoryCount = 0
+		self.inventoryTemperature = 0
+		return
+	end
+
+	-- Remove the Fluid Filter if it doesn't exist anymore --
+	if self.filter ~= nil and game.fluid_prototypes[self.filter] == nil then
+		self.filter = nil
+		return
+	end
 end

--- a/scripts/objects/fluid-interactor.lua
+++ b/scripts/objects/fluid-interactor.lua
@@ -68,8 +68,8 @@ end
 function FI:copySettings(obj)
 	if obj.selectedInv ~= nil then
 		self.selectedInv = obj.selectedInv
-    end
-    if obj.selectedMode ~= nil then
+	end
+	if obj.selectedMode ~= nil then
 		self.selectedMode = obj.selectedMode
 	end
 end
@@ -155,9 +155,9 @@ function FI:getTooltipInfos(GUIObj, gui, justCreated)
 		if deepTank ~= nil and deepTank.ent ~= nil then
 			i = i + 1
 			local fluid
-			if deepTank.filter ~= nil and game.fluid_prototypes[deepTank.filter] ~= nil then
+			if deepTank.filter ~= nil then
 				fluid = deepTank.filter
-			elseif deepTank.inventoryFluid ~= nil and game.fluid_prototypes[deepTank.inventoryFluid] ~= nil then
+			elseif deepTank.inventoryFluid ~= nil then
 				fluid = deepTank.inventoryFluid
 			end
 
@@ -234,9 +234,6 @@ function FI:updateInventory()
 			break
 		end
 	end
-	
-	-- Check if the Fluid still exist --
-	if localFluid ~= nil and game.fluid_prototypes[localFluid.name] == nil then return end
 
     -- Input mode --
     if self.selectedMode == "input" then

--- a/scripts/objects/gui-object.lua
+++ b/scripts/objects/gui-object.lua
@@ -396,8 +396,6 @@ end
 
 -- Create Item Frame --
 function GO:addItemFrame(item, amount, gui)
-    -- Check the Item --
-    if game.item_prototypes[item] == nil then return end
     -- Create the Frame --
     local frame = self:addFrame("", gui, "horizontal")
     -- Create the Sprite --
@@ -452,7 +450,7 @@ function createDNInventoryFrame(GUIObj, gui, MFPlayer, buttonFirstName, inventor
             local name = deepTank.inventoryFluid or deepTank.filter
             local count = deepTank.inventoryCount or 0
             -- Check the Item --
-		    if name == nil or game.fluid_prototypes[name] == nil then goto continue end
+            if name == nil then goto continue end
             -- Check the Filter --
             if MFPlayer.varTable.tmpLocal ~= nil and Util.getLocFluidName(name)[1] ~= nil then
                 local locName = MFPlayer.varTable.tmpLocal[Util.getLocFluidName(name)[1]]
@@ -476,7 +474,7 @@ function createDNInventoryFrame(GUIObj, gui, MFPlayer, buttonFirstName, inventor
             local name = deepStorage.inventoryItem or deepStorage.filter
             local count = deepStorage.inventoryCount or 0
             -- Check the Item --
-            if name == nil or game.item_prototypes[name] == nil then goto continue end
+            if name == nil then goto continue end
             -- Check the Filter --
             if MFPlayer.varTable.tmpLocal ~= nil and Util.getLocItemName(name)[1] ~= nil then
                 local locName = MFPlayer.varTable.tmpLocal[Util.getLocItemName(name)[1]]
@@ -495,8 +493,6 @@ function createDNInventoryFrame(GUIObj, gui, MFPlayer, buttonFirstName, inventor
     -- Look for all Items --
     if showInventory == true then
         for name, count in pairs(inventory.inventory) do
-            -- Check the Item --
-            if name == nil or count == nil or count == 0 or game.item_prototypes[name] == nil then goto continue  end
             -- Check the Filter --
             if MFPlayer.varTable.tmpLocal ~= nil and Util.getLocItemName(name)[1] ~= nil then
                 local locName = MFPlayer.varTable.tmpLocal[Util.getLocItemName(name)[1]]
@@ -521,7 +517,6 @@ function createPlayerInventoryFrame(GUIObj, gui, MFPlayer, columnsNumber, button
     -- Look for all Items --
     for name, count in pairs(MFPlayer.ent.get_main_inventory().get_contents()) do
         -- Check the Item --
-        if name == nil or count == nil or count == 0 or game.item_prototypes[name] == nil then goto continue  end
         if game.item_prototypes[name].type == "item-with-tags" then goto continue end --workaround, tags could be recorded but as of 0.0.197 are forgotten
         -- Check the Filter --
         if MFPlayer.varTable.tmpLocal ~= nil and Util.getLocItemName(name)[1] ~= nil then

--- a/scripts/objects/internal-inventory.lua
+++ b/scripts/objects/internal-inventory.lua
@@ -42,19 +42,13 @@ function INV:rescan()
 	self.maxCapacity = _mfBaseMaxItems + (_mfDataStorageCapacity*self.dataNetwork:dataStoragesCount())
 	-- Get the used Capacity --
 	self.usedCapacity = 0
-	for item, count in pairs(self.inventory) do
-		-- Check if the Item still exist --
-		if game.item_prototypes[item] == nil then
-			self.inventory[item] = nil
-		else
-			self.usedCapacity = self.usedCapacity + count
-		end
+	for _, count in pairs(self.inventory) do
+		self.usedCapacity = self.usedCapacity + count
 	end
 end
 
 -- Return remaining capacity --
 function INV:remCap()
-	self:rescan()
 	return self.maxCapacity - self.usedCapacity
 end
 
@@ -128,10 +122,6 @@ end
 
 -- Get the Tooltip --
 function INV:getTooltipInfos(GUIObj, gui)
-
-	-- Rescan the Inventory --
-	self:rescan()
-	
 	-- Create the Title --
 	local frame = GUIObj:addTitledFrame("", gui, "vertical", {"gui-description.Inventory"}, _mfOrange)
 
@@ -149,11 +139,8 @@ function INV:getTooltipInfos(GUIObj, gui)
 
 	-- Look for all Items --
 	for name, count in pairs(self.inventory) do
-		-- Check the Item --
-		if name == nil or count == nil or count == 0 or game.item_prototypes[name] == nil then goto continue end
 		-- Create the Button --
 		Util.itemToFrame(name, count, GUIObj, table)
-		::continue::
 	end
 
 end

--- a/scripts/objects/matter-interactor.lua
+++ b/scripts/objects/matter-interactor.lua
@@ -120,7 +120,7 @@ function MI:getTooltipInfos(GUIObj, gui, justCreated)
 	GUIObj:addDataNetworkFrame(gui, self)
 
 	-- Update the Filter --
-	if game.item_prototypes[self.selectedFilter] ~= nil and GUIObj["MIFilter" .. tostring(self.ent.unit_number)] ~= nil then
+	if self.selectedFilter ~= nil and GUIObj["MIFilter" .. tostring(self.ent.unit_number)] ~= nil then
 		GUIObj["MIFilter" .. tostring(self.ent.unit_number)].elem_value = self.selectedFilter
 	end
 
@@ -130,7 +130,7 @@ function MI:getTooltipInfos(GUIObj, gui, justCreated)
 	local frame = GUIObj:addTitledFrame("", gui, "vertical", {"gui-description.Inventory"}, _mfOrange)
 
 	-- Create the Filter Label --
-	local filterName = Util.getLocItemName(self.selectedFilter) or {"gui-description.None"}
+	local filterName = self.selectedFilter ~= nil and Util.getLocItemName(self.selectedFilter) or {"gui-description.None"}
 	GUIObj:addDualLabel(frame, {"", {"gui-description.Filter"}, ":"}, filterName, _mfOrange, _mfGreen)
 
 	-- Create the Inventory Button --
@@ -150,7 +150,7 @@ function MI:getTooltipInfos(GUIObj, gui, justCreated)
 	-- Create the Filter Selection --
 	GUIObj:addLabel("", titleFrame, {"gui-description.ChangeFilter"}, _mfOrange)
 	local filter = GUIObj:addFilter("MIFilter" .. tostring(self.ent.unit_number), titleFrame, {"gui-description.FilterSelect"}, true, "item", 40)
-	if game.item_prototypes[self.selectedFilter] ~= nil then filter.elem_value = self.selectedFilter end
+	if self.selectedFilter ~= nil then filter.elem_value = self.selectedFilter end
 
 	-- Create the Mode Selection --
 	GUIObj:addLabel("", titleFrame, {"gui-description.SelectMode"}, _mfOrange)
@@ -184,9 +184,9 @@ function MI:getTooltipInfos(GUIObj, gui, justCreated)
 		if deepStorage ~= nil and deepStorage.ent ~= nil then
 			i = i + 1
 			local item
-			if deepStorage.filter ~= nil and game.item_prototypes[deepStorage.filter] ~= nil then
+			if deepStorage.filter ~= nil then
 				item = deepStorage.filter
-			elseif deepStorage.inventoryItem ~= nil and game.item_prototypes[deepStorage.inventoryItem] ~= nil then
+			elseif deepStorage.inventoryItem ~= nil then
 				item = deepStorage.inventoryItem
 			end
 
@@ -280,8 +280,6 @@ function MI:updateInventory()
     if self.selectedMode == "input" then
         -- Itinerate the Inventory --
 		for item, count in pairs(inv.get_contents()) do
-			-- Check the Item --
-			if game.item_prototypes[item] == nil then return end
             -- Add Items to the Data Inventory --
             local amountAdded = dataInv:addItem(item, count)
             -- Remove Items from the local Inventory --
@@ -293,8 +291,6 @@ function MI:updateInventory()
     elseif self.selectedMode == "output" then
         -- Return if the Filter is nil --
         if self.selectedFilter == nil then return end
-        -- Check if the Item still exist --
-        if game.item_prototypes[self.selectedFilter] == nil then return end
         -- Get Items count from the Data Inventory --
         local returnedItems = dataInv:hasItem(self.selectedFilter)
         -- Return if there are no Items --
@@ -340,4 +336,11 @@ function MI:blueprintTagsToSettings(tags)
 	end
 	-- be careful of a nil selectedMode
 	if tags["selectedMode"] then self.selectedMode = tags["selectedMode"] end
+end
+
+-- Check stored data, and remove invalid record
+function MI:validate()
+	if game.item_prototypes[self.selectedFilter] == nil then
+		self.selectedFilter = nil
+	end
 end

--- a/scripts/objects/mobile-factory.lua
+++ b/scripts/objects/mobile-factory.lua
@@ -78,12 +78,14 @@ function MF:new(args)
 	t.jumpDriveObj = t.jumpDriveObj or JD:new(t)
 
 	t.MF = t
-	UpSys.addObj(t)
+	if not args or not args.refreshObj then
+		UpSys.addObj(t)
+	end
 	return t
 end
 
-function MF:refresh(obj)
-  MF:new({refreshObj = obj})
+function MF:refresh()
+  MF:new({refreshObj = self})
 end
 
 -- Constructor for a placed Mobile Factory --
@@ -174,9 +176,9 @@ function MF:getTooltipInfos(GUIObj, gui, justCreated)
 				if deepTank ~= nil and deepTank.ent ~= nil then
 					i = i + 1
 					local itemText = {"", " (", {"gui-description.Empty"}, " - ", deepTank.player, ")"}
-					if deepTank.filter ~= nil and game.fluid_prototypes[deepTank.filter] ~= nil then
+					if deepTank.filter ~= nil then
 						itemText = {"", " (", game.fluid_prototypes[deepTank.filter].localised_name, " - ", deepTank.player, ")"}
-					elseif deepTank.inventoryFluid ~= nil and game.fluid_prototypes[deepTank.inventoryFluid] ~= nil then
+					elseif deepTank.inventoryFluid ~= nil then
 						itemText = {"", " (", game.fluid_prototypes[deepTank.inventoryFluid].localised_name, " - ", deepTank.player, ")"}
 					end
 					invs[k+1] = {"", {"gui-description.DT"}, " ", tostring(deepTank.ID), itemText}
@@ -223,7 +225,7 @@ function MF:update(event)
 	-- Get the current tick --
 	local tick = event.tick
 
-	-- Update the Internal Inventory --
+	-- Update the Internal Inventory capacity --
 	if tick%_eventTick80 == 0 then self.II:rescan() end
 	-- Check if the Mobile Factory has to TP --
 	if self.onTP and game.tick - self.tpCurrentTick > 30 then self:TPMobileFactoryPart2() end
@@ -1165,5 +1167,21 @@ function MF:updateClonedEntity(ents)
 	elseif ents.original.type == "accumulator" then
 		-- If the Entity is an Accumulator --
 		Util.syncEnergy(ents.original, ents.cloned)
+	end
+end
+
+-- Check stored data, and remove invalid record
+function MF:validate()
+	-- Jump Drive location icons
+	for _, loc in pairs(self.jumpDriveObj.locationTable) do
+		if loc.filter ~= nil and game.recipe_prototypes[loc.filter] == nil then
+			loc.filter = nil
+		end
+	end
+	-- Internal Inventory items
+	for item, _ in pairs(self.II.inventory) do
+		if game.item_prototypes[item] == nil then
+			self.II.inventory[item] = nil
+		end
 	end
 end

--- a/scripts/objects/network-access-point.lua
+++ b/scripts/objects/network-access-point.lua
@@ -140,26 +140,23 @@ end
 
 -- Create all Signals --
 function NAP:createDNSignals()
-
-    -- Create the Inventory Signal --
+	-- Create the Inventory Signal --
 	self.ent.get_control_behavior().parameters = nil
 	local i = 1
 	for name, count in pairs(self.dataNetwork.invObj.inventory) do
 		-- Create and send the Signal --
-		if game.item_prototypes[name] ~= nil then
-			local signal = {signal={type="item", name=name},count=count}
-			self.ent.get_control_behavior().set_signal(i, signal)
-			-- Increament the Slot --
-			i = i + 1
-			-- Stop if there are to much Items --
-			if i > 999 then break end
-		end
+		local signal = {signal={type="item", name=name},count=count}
+		self.ent.get_control_behavior().set_signal(i, signal)
+		-- Increament the Slot --
+		i = i + 1
+		-- Stop if there are to much Items --
+		if i > 999 then break end
 	end
-	
+
 	-- Create the Deep Storages Signals --
 	for k, ds in pairs(self.dataNetwork.DSRTable) do
 		-- Create and send the Signal --
-		if ds.inventoryItem ~= nil and game.item_prototypes[ds.inventoryItem] ~= nil then
+		if ds.inventoryItem ~= nil then
 			local signal = {signal={type="item", name=ds.inventoryItem}, count=math.min(ds.inventoryCount, 2e9)}
 			self.ent.get_control_behavior().set_signal(i, signal)
 			-- Increament the Slot --
@@ -172,7 +169,7 @@ function NAP:createDNSignals()
 	-- Create the Deep Tanks Signals --
 	for k, dtk in pairs(self.dataNetwork.DTKTable) do
 		-- Create and send the Signal --
-		if dtk.inventoryFluid ~= nil and game.fluid_prototypes[dtk.inventoryFluid] ~= nil then
+		if dtk.inventoryFluid ~= nil then
 			local signal = {signal={type="fluid", name=dtk.inventoryFluid} ,count=dtk.inventoryCount}
 			self.ent.get_control_behavior().set_signal(i, signal)
 			-- Increament the Slot --
@@ -180,8 +177,7 @@ function NAP:createDNSignals()
 			-- Stop if there are to much Items --
 			if i > 999 then break end
 		end
-    end
-    
+	end
 end
 
 -- Calculate the Total Consumption --

--- a/scripts/objects/network-explorer.lua
+++ b/scripts/objects/network-explorer.lua
@@ -69,7 +69,7 @@ function NE:update()
 	if valid(self) == false then
 		self:remove()
 		return
-    end
+	end
 
     -- Try to find a Network Access Point if needed --
 	if valid(self.networkAccessPoint) == false then
@@ -215,7 +215,7 @@ function NE.transferItemsFromDS(DS, inv, count)
 	-- Check all values --
 	if DS == nil or inv == nil then return end
 	local item = DS.inventoryItem
-	if item == nil or game.item_prototypes[item] == nil then return end
+	if item == nil then return end
 	local half = (count or 1) < 1 and true or false
 	if count == nil or count <= 0 then count = game.item_prototypes[item].stack_size end
 
@@ -238,7 +238,7 @@ function NE.transferItemsFromDNInv(NE, inv, item, count)
 	-- Check all values --
 	if NE == nil or inv == nil then return end
 	local DNInv = NE.dataNetwork.invObj
-	if item == nil or game.item_prototypes[item] == nil then return end
+	if item == nil then return end
 	local half = (count or 1) < 1 and true or false
 	if count == nil or count <= 0 then count = game.item_prototypes[item].stack_size end
 
@@ -261,7 +261,7 @@ function NE.transferItemsFromPInv(PInv, PName, NE, item, count)
 	-- Check all values --
 	if PInv == nil or NE == nil then return end
 	local DNInv = NE.dataNetwork.invObj
-	if item == nil or game.item_prototypes[item] == nil then return end
+	if item == nil then return end
 	local half = (count or 1) < 1 and true or false
 	if count == nil or count <= 0 then count = game.item_prototypes[item].stack_size end
 	local inserted = 0

--- a/scripts/objects/ore-cleaner.lua
+++ b/scripts/objects/ore-cleaner.lua
@@ -135,9 +135,9 @@ function OC:getTooltipInfos(GUIObj, gui, justCreated)
 			if deepStorage ~= nil and deepStorage.ent ~= nil then
 				i = i + 1
 				local itemText = {"", " (", {"gui-description.Empty"}, " - ", deepStorage.player, ")"}
-				if deepStorage.filter ~= nil and game.item_prototypes[deepStorage.filter] ~= nil then
+				if deepStorage.filter ~= nil then
 					itemText = {"", " (", game.item_prototypes[deepStorage.filter].localised_name, ")"}
-				elseif deepStorage.inventoryItem ~= nil and game.item_prototypes[deepStorage.inventoryItem] ~= nil then
+				elseif deepStorage.inventoryItem ~= nil then
 					itemText = {"", " (", game.item_prototypes[deepStorage.inventoryItem].localised_name, ")"}
 				end
 				invs[k+1] = {"", {"gui-description.DS"}, " ", tostring(deepStorage.ID), itemText}
@@ -248,8 +248,8 @@ function OC:collectOres(event)
 	-- Check if there is a room for all products
 	local deepStorages = {}
 	for _, product in pairs(listProducts) do
-		-- Check if a Name was found, and Item Prototype exists --
-		if product.name == nil or product.type ~= 'item' or game.item_prototypes[product.name] == nil then
+		-- Check if product is fluid --
+		if product.type ~= 'item' then
 			-- Remove unmineable patch from Ore Table
 			table.remove(self.oreTable, randomNum)
 			return

--- a/utils/functions.lua
+++ b/utils/functions.lua
@@ -205,30 +205,22 @@ end
 
 -- Return the localised Entity Name --
 function Util.getLocEntityName(entName)
-	if game.entity_prototypes[entName] ~= nil then
-		return game.entity_prototypes[entName].localised_name
-	end
+	return game.entity_prototypes[entName].localised_name
 end
 
 -- Return the localised Item Name --
 function Util.getLocItemName(itemName)
-	if game.item_prototypes[itemName] ~= nil then
-		return game.item_prototypes[itemName].localised_name
-	end
+	return game.item_prototypes[itemName].localised_name
 end
 
 -- Return the localised Fluid Name --
 function Util.getLocFluidName(fluidName)
-	if game.fluid_prototypes[fluidName] ~= nil then
-		return game.fluid_prototypes[fluidName].localised_name
-	end
+	return game.fluid_prototypes[fluidName].localised_name
 end
 
 -- Return the localised Recipe Name --
 function Util.getLocRecipeName(recipeName)
-	if game.recipe_prototypes[recipeName] ~= nil then
-		return game.recipe_prototypes[recipeName].localised_name
-	end
+	return game.recipe_prototypes[recipeName].localised_name
 end
 
 -- Reset an Animation --
@@ -468,8 +460,6 @@ end
 
 -- Util: Create a frame from an Item --
 function Util.itemToFrame(name, count, GUIObj, gui)
-	-- Check value --
-	if name == nil or count == nil or game.item_prototypes[name] == nil then return end
 	-- Create the Button --
 	local button = GUIObj:addButton("", gui, "item/" .. name, "item/" .. name, {"", Util.getLocItemName(name), ": ", Util.toRNumber(count)}, 37, true, true, count)
 	button.style = "MF_Fake_Button_Blue"
@@ -479,8 +469,6 @@ end
 
 -- Util: Create a frame from a Fluid --
 function Util.fluidToFrame(name, count, GUIObj, gui)
-	-- Check value --
-	if name == nil or count == nil or game.fluid_prototypes[name] == nil then return end
 	-- Create the Button --
 	local button = GUIObj:addButton("", gui, "fluid/" .. name, "fluid/" .. name, {"", Util.getLocFluidName(name), ": ", Util.toRNumber(count)}, 37, true, true, count)
 	button.style = "MF_Fake_Button_Purple"

--- a/utils/place-and-remove.lua
+++ b/utils/place-and-remove.lua
@@ -129,12 +129,16 @@ function somethingWasPlaced(event)
 		if event.tags and obj.blueprintTagsToSettings then
 			obj:blueprintTagsToSettings(event.tags)
 		end
-		-- Check if there are Items Tags --
+		-- Check if there are Item Tags --
 		if event.stack ~= nil and event.stack.valid_for_read == true and event.stack.type == "item-with-tags" then
 			local tags = event.stack.get_tag("Infos")
 			if tags ~= nil then
 				obj:itemTagsToContent(tags)
 			end
+		end
+		-- Validate properties taken from Blueprint or Item Tags
+		if obj.validate then
+			obj:validate()
 		end
 	end
 


### PR DESCRIPTION
Unified check of stored data prototypes, via obj:validate(). That solves two problems:
Firstly, it prevent crashes when some mod got removed, but MF still have a records if its data. There are plenty of checks to prevent that... but it still doesn't cover all cases. I'm often using heavily modded saves in mf-only game during devolopment(Less mods makes factorio [re]load faster, but all my good testing saves from real modded games). That's my regular workflow, so i've seen a plenty of such crashes.

Secondly, it removes needless checks from runtime, as prototypes can't just disappear. They need to be checked only when mods actually been changed(Added, removed, updated - and all that triggers on_configuration_change), or when applying serialized data(tags, blueprints - they could have been created with mods which not presented anymore). And that's all. No need to check it during regular on_tick updates, that's just a waste of processing time.