### PR TITLE
fixed teleportation bugs

### DIFF
--- a/scripts/GUI/gui.lua
+++ b/scripts/GUI/gui.lua
@@ -591,7 +591,7 @@ function GUI.buttonClicked(event)
 		if string.match(event.element.name, "TPGUILoc") then
 			local GUIObj = MFPlayer.GUI["MFTPGUI"]
 			local jumpDrive = GUIObj.MF.jumpDriveObj
-			local location = split(event.element.name, ",")[2]
+			local location = string.sub(event.element.name, string.len("TPGUILoc,")+1 )
 			-- Start the Jump --
 			if event.button == defines.mouse_button_type.left then
 				jumpDrive:jump(location)

--- a/scripts/objects/mobile-factory.lua
+++ b/scripts/objects/mobile-factory.lua
@@ -765,7 +765,7 @@ function MF:TPMobileFactoryPart2()
 	-- Get the distance --
 	local distance = Util.distance({self.tpLocation.posX,self.tpLocation.posY}, self.ent.position)
 	-- Remove the Jump Drive Charge --
-	self.jumpDriveObj.charge = math.min(0, self.jumpDriveObj.charge - distance)
+	self.jumpDriveObj.charge = math.max(0, self.jumpDriveObj.charge - distance)
 	-- Remove the Quatron --
 	if self.tpLocation.surface ~= self.ent.surface then
 		self.internalQuatronObj:removeQuatron(1000)


### PR DESCRIPTION
fixed 2 bugs related to the teleportation gui and jump-charges

- a teleportation gui jump location could not be used or removed, if its name contained a comma
- teleporting any distance would set the mobile factory jump charge to zero
